### PR TITLE
Add networkx transformation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,4 +30,4 @@ jobs:
     - name: Test project
       run: |
         poetry install
-        poetry run pytest
+        poetry run pytest -vvv -m "not slow"

--- a/gqlalchemy/transformations.py
+++ b/gqlalchemy/transformations.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2016-2021 Memgraph Ltd. [https://memgraph.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, Iterator
+
+import networkx as nx
+
+from gqlalchemy.utilities import to_cypher_labels, to_cypher_properties
+
+__all__ = (
+    "nx_to_cypher",
+    "nx_edges_to_cypher",
+    "nx_nodes_to_cypher",
+)
+
+
+def nx_nodes_to_cypher(graph: nx.Graph) -> Iterator[str]:
+    """Generates a Cypher queries for creating nodes"""
+    for nx_id, data in graph.nodes(data=True):
+        yield _create_node(nx_id, data)
+
+
+def nx_edges_to_cypher(graph: nx.Graph) -> Iterator[str]:
+    """Generates a Cypher queries for creating edges"""
+    for n1, n2, data in graph.edges(data=True):
+        yield _create_edge(n1, n2, data)
+
+
+def nx_to_cypher(graph: nx.Graph) -> Iterator[str]:
+    """Generates a Cypher queries for creating graph"""
+
+    yield from nx_nodes_to_cypher(graph)
+    yield from nx_edges_to_cypher(graph)
+
+
+def _create_node(nx_id: int, properties: Dict[str, Any]) -> str:
+    """Returns Cypher query for node creation"""
+    if "id" not in properties:
+        properties["id"] = nx_id
+    labels_str = to_cypher_labels(properties.pop("labels", ""))
+    properties_str = to_cypher_properties(properties)
+
+    return f"CREATE ({labels_str} {properties_str});"
+
+
+def _create_edge(from_id: int, to_id: int, properties: Dict[str, Any]) -> str:
+    """Returns Cypher query for edge creation."""
+    edge_type = to_cypher_labels(properties.get("type", "TO"))
+    properties.pop("type", None)
+    properties_str = to_cypher_properties(properties)
+
+    return f"MATCH (n {{id: {from_id}}}), (m {{id: {to_id}}}) CREATE (n)-[{edge_type} {properties_str}]->(m);"

--- a/gqlalchemy/transformations.py
+++ b/gqlalchemy/transformations.py
@@ -121,8 +121,6 @@ def _insert_queries(queries: List[str], host: str, port: int, username: str, pas
         try:
             query = queries.pop()
             memgraph.execute_query(query)
-        except IndexError:
-            break
         except mgclient.DatabaseError as e:
             queries.append(query)
             logging.getLogger(__file__).warning(f"Ignoring database error: {e}")

--- a/gqlalchemy/transformations.py
+++ b/gqlalchemy/transformations.py
@@ -90,25 +90,24 @@ def _check_for_index_hint(
     memgraph = Memgraph(host, port, username, password, encrypted)
     indexes = memgraph.get_indexes()
     if len(indexes) == 0:
-        logging.warning(f"Be careful you do not have any indexes set up, the queries will take longer than expected!")
+        logging.getLogger(__file__).warning(
+            f"Be careful you do not have any indexes set up, the queries will take longer than expected!"
+        )
 
 
 def _insert_queries(queries: List[str], host, port, username, password, encrypted) -> None:
     """Used by multiprocess insertion of nx into memgraph, works on a chunk of queries."""
-    conn = mgclient.connect(host=host, port=port, username=username, password=password, encrypted=encrypted)
+    memgraph = Memgraph(host, port, username, password, encrypted)
     while len(queries) > 0:
         try:
             query = queries.pop()
-            cursor = conn.cursor()
-            cursor.execute(query)
-            cursor.fetchall()
+            memgraph.execute_query(query)
         except IndexError:
             break
         except mgclient.DatabaseError as e:
             queries.append(query)
             logging.getLogger(__file__).warning(f"Ignoring database error: {str(e)}")
             continue
-        conn.commit()
 
 
 def _nx_nodes_to_cypher(graph: nx.Graph) -> Iterator[str]:

--- a/gqlalchemy/transformations.py
+++ b/gqlalchemy/transformations.py
@@ -40,7 +40,7 @@ def nx_to_cypher(graph: nx.Graph) -> Iterator[str]:
 
 def nx_graph_to_memgraph_parallel(
     graph: nx.Graph,
-    host: str = "127.0.01",
+    host: str = "127.0.0.1",
     port: int = 7687,
     username: str = "",
     password: str = "",
@@ -81,7 +81,7 @@ def nx_graph_to_memgraph_parallel(
 
 
 def _check_for_index_hint(
-    host: str = "127.0.01",
+    host: str = "127.0.0.1",
     port: int = 7687,
     username: str = "",
     password: str = "",

--- a/gqlalchemy/transformations.py
+++ b/gqlalchemy/transformations.py
@@ -12,52 +12,107 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Iterator
+import logging
+import multiprocessing as mp
+from typing import Any, Dict, Iterator, List, Union
 
+import mgclient
 import networkx as nx
 
 from gqlalchemy.utilities import to_cypher_labels, to_cypher_properties
 
-__all__ = (
-    "nx_to_cypher",
-    "nx_edges_to_cypher",
-    "nx_nodes_to_cypher",
-)
+__all__ = ("nx_to_cypher", "nx_graph_to_memgraph_parallel")
 
 
-def nx_nodes_to_cypher(graph: nx.Graph) -> Iterator[str]:
-    """Generates a Cypher queries for creating nodes"""
-    for nx_id, data in graph.nodes(data=True):
-        yield _create_node(nx_id, data)
-
-
-def nx_edges_to_cypher(graph: nx.Graph) -> Iterator[str]:
-    """Generates a Cypher queries for creating edges"""
-    for n1, n2, data in graph.edges(data=True):
-        yield _create_edge(n1, n2, data)
+class NetworkXGraphConstants:
+    LABELS = "labels"
+    TYPE = "type"
+    ID = "id"
 
 
 def nx_to_cypher(graph: nx.Graph) -> Iterator[str]:
     """Generates a Cypher queries for creating graph"""
 
-    yield from nx_nodes_to_cypher(graph)
-    yield from nx_edges_to_cypher(graph)
+    yield from _nx_nodes_to_cypher(graph)
+    yield from _nx_edges_to_cypher(graph)
+
+
+def nx_graph_to_memgraph_parallel(graph: nx.Graph, host: str = "127.0.0.1", port: int = 7687) -> None:
+    """Generates a Cypher queries and inserts data into Memgraph in parallel"""
+    num_of_processes = mp.cpu_count() // 2
+    for queries_gen in [_nx_nodes_to_cypher(graph), _nx_edges_to_cypher(graph)]:
+        queries = list(queries_gen)
+        chunk_size = len(queries) // num_of_processes
+        processes = []
+        for i in range(num_of_processes):
+            process_queries = queries[i * chunk_size : chunk_size * (i + 1)]
+            processes.append(
+                mp.Process(
+                    target=_insert_queries,
+                    args=(process_queries, host, port),
+                )
+            )
+        for p in processes:
+            p.start()
+        for p in processes:
+            p.join()
+
+
+def _insert_queries(queries: List[str], host: str, port: int) -> None:
+    """Used by multiprocess insertion of nx into memgraph, works on a chunk of queries."""
+    conn = mgclient.connect(host=host, port=port)
+    while len(queries) > 0:
+        try:
+            query = queries.pop()
+            cursor = conn.cursor()
+            cursor.execute(query)
+            cursor.fetchall()
+        except IndexError:
+            break
+        except mgclient.DatabaseError as e:
+            queries.append(query)
+            logging.getLogger(__file__).warning(f"Ignoring database error: {str(e)}")
+            continue
+        conn.commit()
+
+
+def _nx_nodes_to_cypher(graph: nx.Graph) -> Iterator[str]:
+    """Generates a Cypher queries for creating nodes"""
+    for nx_id, data in graph.nodes(data=True):
+        yield _create_node(nx_id, data)
+
+
+def _nx_edges_to_cypher(graph: nx.Graph) -> Iterator[str]:
+    """Generates a Cypher queries for creating edges"""
+    for n1, n2, data in graph.edges(data=True):
+        from_label = graph.nodes[n1].get(NetworkXGraphConstants.LABELS, "")
+        to_label = graph.nodes[n2].get(NetworkXGraphConstants.LABELS, "")
+        yield _create_edge(n1, n2, from_label, to_label, data)
 
 
 def _create_node(nx_id: int, properties: Dict[str, Any]) -> str:
     """Returns Cypher query for node creation"""
     if "id" not in properties:
         properties["id"] = nx_id
-    labels_str = to_cypher_labels(properties.pop("labels", ""))
-    properties_str = to_cypher_properties(properties)
+    labels_str = to_cypher_labels(properties.get(NetworkXGraphConstants.LABELS, ""))
+    properties_without_labels = {k: v for k, v in properties.items() if k != NetworkXGraphConstants.LABELS}
+    properties_str = to_cypher_properties(properties_without_labels)
 
     return f"CREATE ({labels_str} {properties_str});"
 
 
-def _create_edge(from_id: int, to_id: int, properties: Dict[str, Any]) -> str:
+def _create_edge(
+    from_id: int,
+    to_id: int,
+    from_label: Union[str, List[str]],
+    to_label: Union[str, List[str]],
+    properties: Dict[str, Any],
+) -> str:
     """Returns Cypher query for edge creation."""
-    edge_type = to_cypher_labels(properties.get("type", "TO"))
-    properties.pop("type", None)
+    edge_type = to_cypher_labels(properties.get(NetworkXGraphConstants.TYPE, "TO"))
+    properties.pop(NetworkXGraphConstants.TYPE, None)
     properties_str = to_cypher_properties(properties)
+    from_label_str = to_cypher_labels(from_label)
+    to_label_str = to_cypher_labels(to_label)
 
-    return f"MATCH (n {{id: {from_id}}}), (m {{id: {to_id}}}) CREATE (n)-[{edge_type} {properties_str}]->(m);"
+    return f"MATCH (n{from_label_str} {{id: {from_id}}}), (m{to_label_str} {{id: {to_id}}}) CREATE (n)-[{edge_type} {properties_str}]->(m);"

--- a/poetry.lock
+++ b/poetry.lock
@@ -83,6 +83,14 @@ toml = {version = "*", optional = true, markers = "extra == \"toml\""}
 toml = ["toml"]
 
 [[package]]
+name = "decorator"
+version = "4.4.2"
+description = "Decorators for Humans"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*"
+
+[[package]]
 name = "flake8"
 version = "3.9.2"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -118,6 +126,30 @@ description = "Experimental type system extensions for programs checked with the
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "networkx"
+version = "2.5.1"
+description = "Python package for creating and manipulating graphs and networks"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+decorator = ">=4.3,<5"
+
+[package.extras]
+all = ["numpy", "scipy", "pandas", "matplotlib", "pygraphviz", "pydot", "pyyaml", "lxml", "pytest"]
+gdal = ["gdal"]
+lxml = ["lxml"]
+matplotlib = ["matplotlib"]
+numpy = ["numpy"]
+pandas = ["pandas"]
+pydot = ["pydot"]
+pygraphviz = ["pygraphviz"]
+pytest = ["pytest"]
+pyyaml = ["pyyaml"]
+scipy = ["scipy"]
 
 [[package]]
 name = "packaging"
@@ -280,7 +312,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "3ef309a2d56f607a10f069ba51e9aace92e0dc2337255feb0c9cee48ff013c16"
+content-hash = "076de5836b4b9e15bf0d247405528552fe609e0e9237b53e48d372f2b8f24733"
 
 [metadata.files]
 appdirs = [
@@ -361,6 +393,10 @@ coverage = [
     {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
     {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
+decorator = [
+    {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
+    {file = "decorator-4.4.2.tar.gz", hash = "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"},
+]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
     {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
@@ -376,6 +412,10 @@ mccabe = [
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+networkx = [
+    {file = "networkx-2.5.1-py3-none-any.whl", hash = "sha256:0635858ed7e989f4c574c2328380b452df892ae85084144c73d8cd819f0c4e06"},
+    {file = "networkx-2.5.1.tar.gz", hash = "sha256:109cd585cac41297f71103c3c42ac6ef7379f29788eb54cb751be5a663bb235a"},
 ]
 packaging = [
     {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ exclude = '''
 [tool.poetry.dependencies]
 python = "^3.8"
 pymgclient = "^1.0.0"
+networkx = "^2.5.1"
 
 [tool.poetry.dev-dependencies]
 black = "^21.5b1"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,11 @@
 [pytest]
 addopts =
-  -vv --quiet --maxfail=10
+  -vv --quiet --maxfail=10 --durations=20
   --black
   --flake8
   --cov-report html --cov-report term --cov=gqlalchemy
 timeout = 300
 python_files = test_*.py
 testpaths = tests gqlalchemy
+markers =
+  slow: slow tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ def memgraph() -> Memgraph:
     memgraph = Memgraph()
     memgraph.ensure_indexes([])
     memgraph.ensure_constraints([])
+    memgraph.drop_database()
     return memgraph
 
 

--- a/tests/intergration/__init__.py
+++ b/tests/intergration/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2016-2021 Memgraph Ltd. [https://memgraph.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/intergration/test_networkx.py
+++ b/tests/intergration/test_networkx.py
@@ -18,8 +18,7 @@ import networkx as nx
 import pytest
 from gqlalchemy import Memgraph
 from gqlalchemy.models import MemgraphIndex
-from gqlalchemy.transformations import (nx_graph_to_memgraph_parallel,
-                                        nx_to_cypher)
+from gqlalchemy.transformations import nx_graph_to_memgraph_parallel, nx_to_cypher
 
 
 @pytest.fixture
@@ -75,9 +74,9 @@ def test_simple_index_nx_to_memgraph(memgraph: Memgraph):
     )
     graph.add_edges_from([(1, 2), (1, 3)])
     expected_indexes = {
-        MemgraphIndex("L1"),
-        MemgraphIndex("L2"),
-        MemgraphIndex("L3"),
+        MemgraphIndex("L1", "id"),
+        MemgraphIndex("L2", "id"),
+        MemgraphIndex("L3", "id"),
     }
 
     for query in nx_to_cypher(graph, True):
@@ -120,7 +119,16 @@ def test_nx_to_memgraph(memgraph: Memgraph):
 
 @pytest.mark.timeout(60)
 @pytest.mark.slow
-def test_big_nx_to_memgraph_with_index(memgraph: Memgraph, random_nx_graph: nx.Graph):
+def test_big_nx_to_memgraph_with_manual_index(memgraph: Memgraph, random_nx_graph: nx.Graph):
+    memgraph.create_index(MemgraphIndex("Label", "id"))
+
+    for query in nx_to_cypher(random_nx_graph):
+        memgraph.execute_query(query)
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.slow
+def test_big_nx_to_memgraph(memgraph: Memgraph, random_nx_graph: nx.Graph):
     for query in nx_to_cypher(random_nx_graph, create_index=True):
         memgraph.execute_query(query)
 

--- a/tests/intergration/test_networkx.py
+++ b/tests/intergration/test_networkx.py
@@ -95,6 +95,7 @@ def test_nx_to_memgraph(memgraph: Memgraph):
 
 
 @pytest.mark.timeout(60)
+@pytest.mark.slow
 def test_big_nx_to_memgraph(db: Memgraph, random_nx_graph: nx.Graph):
     db.create_index(MemgraphIndex("Label", "id"))
 
@@ -103,6 +104,7 @@ def test_big_nx_to_memgraph(db: Memgraph, random_nx_graph: nx.Graph):
 
 
 @pytest.mark.timeout(240)
+@pytest.mark.slow
 def test_huge_nx_to_memgraph_parallel(db: Memgraph, big_random_nx_graph: nx.Graph):
     db.create_index(MemgraphIndex("Label", "id"))
 

--- a/tests/intergration/test_networkx.py
+++ b/tests/intergration/test_networkx.py
@@ -22,9 +22,19 @@ from gqlalchemy.transformations import nx_graph_to_memgraph_parallel, nx_to_cyph
 
 
 @pytest.fixture
-def random_nx_graph(number_of_nodes: int = 100000, number_of_edges: int = 150000) -> nx.Graph:
+def random_nx_graph(number_of_nodes=100000, number_of_edges=150000) -> nx.Graph:
     graph = nx.Graph()
+    for i in range(number_of_nodes):
+        graph.add_node(i, labels="Label")
+    for _ in range(number_of_edges):
+        graph.add_edge(randint(0, number_of_nodes), randint(0, number_of_nodes))
 
+    return graph
+
+
+@pytest.fixture
+def big_random_nx_graph(number_of_nodes=200000, number_of_edges=1000000) -> nx.Graph:
+    graph = nx.Graph()
     for i in range(number_of_nodes):
         graph.add_node(i, labels="Label")
     for _ in range(number_of_edges):
@@ -85,7 +95,6 @@ def test_nx_to_memgraph(memgraph: Memgraph):
 
 
 @pytest.mark.timeout(60)
-@pytest.mark.parametrize("random_nx_graph", [(100000, 200000)], indirect=True)
 def test_big_nx_to_memgraph(db: Memgraph, random_nx_graph: nx.Graph):
     db.create_index(MemgraphIndex("Label", "id"))
 
@@ -93,9 +102,8 @@ def test_big_nx_to_memgraph(db: Memgraph, random_nx_graph: nx.Graph):
         db.execute_query(query)
 
 
-@pytest.mark.timeout(180)
-@pytest.mark.parametrize("random_nx_graph", [(100000, 1000000)], indirect=True)
-def test_big_nx_to_memgraph_parallel(db: Memgraph, random_nx_graph: nx.Graph):
+@pytest.mark.timeout(240)
+def test_huge_nx_to_memgraph_parallel(db: Memgraph, big_random_nx_graph: nx.Graph):
     db.create_index(MemgraphIndex("Label", "id"))
 
-    nx_graph_to_memgraph_parallel(random_nx_graph)
+    nx_graph_to_memgraph_parallel(big_random_nx_graph)

--- a/tests/intergration/test_networkx.py
+++ b/tests/intergration/test_networkx.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2016-2021 Memgraph Ltd. [https://memgraph.com]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import networkx as nx
+from gqlalchemy import Memgraph
+from gqlalchemy.transformations import nx_to_cypher
+
+
+def test_simple_nx_to_memgraph(memgraph: Memgraph):
+    graph = nx.Graph()
+    graph.add_nodes_from([1, 2, 3])
+    graph.add_edges_from([(1, 2), (1, 3)])
+
+    for query in nx_to_cypher(graph):
+        memgraph.execute_query(query)
+
+    actual_nodes = list(memgraph.execute_and_fetch("MATCH (n) RETURN n ORDER BY n.id"))
+    assert len(actual_nodes) == 3
+    for i, node in enumerate(actual_nodes):
+        assert node["n"].properties["id"] == i + 1
+        assert node["n"].labels == set()
+
+    actual_edges = list(memgraph.execute_and_fetch("MATCH ()-[e]->() RETURN e"))
+    assert len(actual_edges) == 2
+    for i, edge in enumerate(actual_edges):
+        assert edge["e"].type == "TO"
+
+
+def test_nx_to_memgraph(memgraph: Memgraph):
+    graph = nx.Graph()
+    expected_nodes = [
+        (1, {"labels": "L1", "num": 123}),
+        (2, {"labels": "L1", "num": 123}),
+        (3, {"labels": ["L1", "L2", "L3"], "num": 123}),
+    ]
+    expected_edges = [(1, 2, {"type": "E1", "num": 3.14}), (1, 3, {"type": "E2", "num": 123})]
+    graph.add_nodes_from(expected_nodes)
+    graph.add_edges_from(expected_edges)
+
+    for query in nx_to_cypher(graph):
+        memgraph.execute_query(query)
+
+    actual_nodes = list(memgraph.execute_and_fetch("MATCH (n) RETURN n ORDER BY n.id"))
+    assert len(actual_nodes) == 3
+    for i, node in enumerate(actual_nodes):
+        assert node["n"].properties["id"] == expected_nodes[i][0]
+        if isinstance(expected_nodes[i][1]["labels"], (list, tuple)):
+            assert node["n"].labels == set(expected_nodes[i][1]["labels"])
+        else:
+            assert node["n"].labels == {expected_nodes[i][1]["labels"]}
+        assert node["n"].properties["num"] == expected_nodes[i][1]["num"]
+
+    actual_edges = list(memgraph.execute_and_fetch("MATCH ()-[e]->() RETURN e"))
+    assert len(actual_edges) == 2
+    for i, edge in enumerate(actual_edges):
+        assert edge["e"].type == expected_edges[i][2]["type"]
+        assert edge["e"].properties["num"] == expected_edges[i][2]["num"]

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -112,8 +112,8 @@ def test_nx_create_edge_and_node_with_index():
         "CREATE (:Label1 {id: 1});",
         "CREATE (:Label1:Label2 {name: 'name1', id: 2});",
         "CREATE (:Label1 {id: 3});",
-        "CREATE INDEX ON :Label2;",
-        "CREATE INDEX ON :Label1;",
+        "CREATE INDEX ON :Label2(id);",
+        "CREATE INDEX ON :Label1(id);",
         "MATCH (n:Label1 {id: 1}), (m:Label1:Label2 {id: 2}) CREATE (n)-[:TYPE1 ]->(m);",
         "MATCH (n:Label1:Label2 {id: 2}), (m:Label1 {id: 3}) CREATE (n)-[:TYPE2 {data: 'abc'}]->(m);",
     ]


### PR DESCRIPTION
Integrate networkx graph to cypher queries transformation.
### How to use?

Currently there are two new API calls to `gqlalchemy.tranformations`:
 - `nx_to_cypher`
 - `nx_graph_to_memgraph_parallel`

####  `nx_to_cypher`
 Accepts a networkx graph and translates it into two (or three) groups of cypher queries. The first group is a creation of nodes, second is optional (if the caller passes `create_index` as `True`) you will get queries for creating indexes on `id` property, and this is a creation of edges.

####  `nx_graph_to_memgraph_parallel`
Accepts a networkx graph and connection parameters for creating multiple connections to memgraph which will be used to insert the whole networkx graph in memgraph in parallel. It also supports `create_index` flag, if set the function will create all indexes an `id` property.

Using this module assumes some stuff:
 - If you create nodes with the property `labels` it will be taken as a label and will not be a part of the properties.
 - If you create edges with the property `type` will be taken as a type for node and will not be a part of properties
 - The `id` that networx has for nodes will be set ad id in the node properties.