### PR TITLE
Add support for handling NaN values when converting nx to cypher

### DIFF
--- a/gqlalchemy/transformations.py
+++ b/gqlalchemy/transformations.py
@@ -21,7 +21,7 @@ import networkx as nx
 
 from gqlalchemy import Memgraph
 from gqlalchemy.models import MemgraphIndex
-from gqlalchemy.utilities import to_cypher_labels, to_cypher_properties, to_cypher_value
+from gqlalchemy.utilities import to_cypher_labels, to_cypher_properties, to_cypher_value, NetworkXCypherConfig
 
 __all__ = ("nx_to_cypher", "nx_graph_to_memgraph_parallel")
 
@@ -32,14 +32,14 @@ class NetworkXGraphConstants:
     ID = "id"
 
 
-def nx_to_cypher(graph: nx.Graph, create_index=False) -> Iterator[str]:
+def nx_to_cypher(
+    graph: nx.Graph, create_index=False, config: NetworkXCypherConfig = NetworkXCypherConfig()
+) -> Iterator[str]:
     """Generates a Cypher queries for creating graph"""
 
-    if create_index:
-        yield from _nx_nodes_to_cypher_with_index(graph)
-    else:
-        yield from _nx_nodes_to_cypher(graph)
-    yield from _nx_edges_to_cypher(graph)
+    builder = NetworkXCypherBuilder(create_index=create_index, config=config)
+
+    yield from builder.yield_queries(graph)
 
 
 def nx_graph_to_memgraph_parallel(
@@ -50,12 +50,13 @@ def nx_graph_to_memgraph_parallel(
     password: str = "",
     encrypted: bool = False,
     create_index=False,
+    config: NetworkXCypherConfig = NetworkXCypherConfig(),
 ) -> None:
     """Generates a Cypher queries and inserts data into Memgraph in parallel"""
-    query_groups = []
-    if create_index:
-        query_groups.append(_nx_nodes_to_cypher_with_index(graph))
-    else:
+    builder = NetworkXCypherBuilder(create_index=create_index, config=config)
+    query_groups = builder.yield_query_groups(graph)
+
+    if not create_index:
         _check_for_index_hint(
             host,
             port,
@@ -63,8 +64,7 @@ def nx_graph_to_memgraph_parallel(
             password,
             encrypted,
         )
-        query_groups.append(_nx_nodes_to_cypher(graph))
-    query_groups.append(_nx_edges_to_cypher(graph))
+
     for query_group in query_groups:
         _start_parallel_execution(query_group, host, port, username, password, encrypted)
 
@@ -127,69 +127,93 @@ def _insert_queries(queries: List[str], host: str, port: int, username: str, pas
             continue
 
 
-def _nx_nodes_to_cypher(graph: nx.Graph) -> Iterator[str]:
-    """Generates a Cypher queries for creating nodes"""
-    for nx_id, data in graph.nodes(data=True):
-        yield _create_node(nx_id, data)
+class NetworkXCypherBuilder:
+    def __init__(self, create_index: bool, config: NetworkXCypherConfig):
+        self._create_index_prop = create_index
+        self._config = config
 
+    def yield_queries(self, graph: nx.Graph) -> Iterator[str]:
+        """Generates a Cypher queries for creating graph"""
 
-def _nx_nodes_to_cypher_with_index(graph: nx.Graph) -> Iterator[str]:
-    """Generates a Cypher queries for creating nodes and indexes"""
-    labels = set()
-    for nx_id, data in graph.nodes(data=True):
-        node_labels = data.get(NetworkXGraphConstants.LABELS, None)
-        if isinstance(node_labels, (list, set)):
-            labels |= set(node_labels)
+        if self._create_index_prop:
+            yield from self._nx_nodes_to_cypher_with_index(graph)
         else:
-            labels.add(node_labels)
-        yield _create_node(nx_id, data)
-    labels.discard(None)
-    for label in labels:
-        yield _create_index(label)
+            yield from self._nx_nodes_to_cypher(graph)
+        yield from self._nx_edges_to_cypher(graph)
 
+    def yield_query_groups(self, graph: nx.Graph) -> List[Iterator[str]]:
+        """Generates a Cypher queries for creating graph by query groups"""
 
-def _nx_edges_to_cypher(graph: nx.Graph) -> Iterator[str]:
-    """Generates a Cypher queries for creating edges"""
-    for n1, n2, data in graph.edges(data=True):
-        from_label = graph.nodes[n1].get(NetworkXGraphConstants.LABELS, "")
-        to_label = graph.nodes[n2].get(NetworkXGraphConstants.LABELS, "")
+        query_groups = []
 
-        n1_id = graph.nodes[n1].get(NetworkXGraphConstants.ID, n1)
-        n2_id = graph.nodes[n2].get(NetworkXGraphConstants.ID, n2)
-        yield _create_edge(n1_id, n2_id, from_label, to_label, data)
+        if self._create_index_prop:
+            query_groups.append(self._nx_nodes_to_cypher_with_index(graph))
+        else:
+            query_groups.append(self._nx_nodes_to_cypher(graph))
 
+        query_groups.append(self._nx_edges_to_cypher(graph))
 
-def _create_node(nx_id: int, properties: Dict[str, Any]) -> str:
-    """Returns Cypher query for node creation"""
-    if "id" not in properties:
-        properties["id"] = nx_id
-    labels_str = to_cypher_labels(properties.get(NetworkXGraphConstants.LABELS, ""))
-    properties_without_labels = {k: v for k, v in properties.items() if k != NetworkXGraphConstants.LABELS}
-    properties_str = to_cypher_properties(properties_without_labels)
+        return query_groups
 
-    return f"CREATE ({labels_str} {properties_str});"
+    def _nx_nodes_to_cypher(self, graph: nx.Graph) -> Iterator[str]:
+        """Generates a Cypher queries for creating nodes"""
+        for nx_id, data in graph.nodes(data=True):
+            yield self._create_node(nx_id, data)
 
+    def _nx_nodes_to_cypher_with_index(self, graph: nx.Graph) -> Iterator[str]:
+        """Generates a Cypher queries for creating nodes and indexes"""
+        labels = set()
+        for nx_id, data in graph.nodes(data=True):
+            node_labels = data.get(NetworkXGraphConstants.LABELS, None)
+            if isinstance(node_labels, (list, set)):
+                labels |= set(node_labels)
+            else:
+                labels.add(node_labels)
+            yield self._create_node(nx_id, data)
+        labels.discard(None)
+        for label in labels:
+            yield self._create_index(label)
 
-def _create_edge(
-    from_id: Union[int, str],
-    to_id: Union[int, str],
-    from_label: Union[str, List[str]],
-    to_label: Union[str, List[str]],
-    properties: Dict[str, Any],
-) -> str:
-    """Returns Cypher query for edge creation."""
-    edge_type = to_cypher_labels(properties.get(NetworkXGraphConstants.TYPE, "TO"))
-    properties.pop(NetworkXGraphConstants.TYPE, None)
-    properties_str = to_cypher_properties(properties)
-    from_label_str = to_cypher_labels(from_label)
-    to_label_str = to_cypher_labels(to_label)
-    from_id_str = to_cypher_value(from_id)
-    to_id_str = to_cypher_value(to_id)
+    def _nx_edges_to_cypher(self, graph: nx.Graph) -> Iterator[str]:
+        """Generates a Cypher queries for creating edges"""
+        for n1, n2, data in graph.edges(data=True):
+            from_label = graph.nodes[n1].get(NetworkXGraphConstants.LABELS, "")
+            to_label = graph.nodes[n2].get(NetworkXGraphConstants.LABELS, "")
 
-    return f"MATCH (n{from_label_str} {{id: {from_id_str}}}), (m{to_label_str} {{id: {to_id_str}}}) CREATE (n)-[{edge_type} {properties_str}]->(m);"
+            n1_id = graph.nodes[n1].get(NetworkXGraphConstants.ID, n1)
+            n2_id = graph.nodes[n2].get(NetworkXGraphConstants.ID, n2)
+            yield self._create_edge(n1_id, n2_id, from_label, to_label, data)
 
+    def _create_node(self, nx_id: int, properties: Dict[str, Any]) -> str:
+        """Returns Cypher query for node creation"""
+        if "id" not in properties:
+            properties["id"] = nx_id
+        labels_str = to_cypher_labels(properties.get(NetworkXGraphConstants.LABELS, ""))
+        properties_without_labels = {k: v for k, v in properties.items() if k != NetworkXGraphConstants.LABELS}
+        properties_str = to_cypher_properties(properties_without_labels, self._config)
 
-def _create_index(label: str, property: str = None):
-    """Returns Cypher query for index creation"""
-    index = MemgraphIndex(label, property)
-    return f"CREATE INDEX ON {index.to_cypher()}(id);"
+        return f"CREATE ({labels_str} {properties_str});"
+
+    def _create_edge(
+        self,
+        from_id: Union[int, str],
+        to_id: Union[int, str],
+        from_label: Union[str, List[str]],
+        to_label: Union[str, List[str]],
+        properties: Dict[str, Any],
+    ) -> str:
+        """Returns Cypher query for edge creation."""
+        edge_type = to_cypher_labels(properties.get(NetworkXGraphConstants.TYPE, "TO"))
+        properties.pop(NetworkXGraphConstants.TYPE, None)
+        properties_str = to_cypher_properties(properties, self._config)
+        from_label_str = to_cypher_labels(from_label)
+        to_label_str = to_cypher_labels(to_label)
+        from_id_str = to_cypher_value(from_id)
+        to_id_str = to_cypher_value(to_id)
+
+        return f"MATCH (n{from_label_str} {{id: {from_id_str}}}), (m{to_label_str} {{id: {to_id_str}}}) CREATE (n)-[{edge_type} {properties_str}]->(m);"
+
+    def _create_index(self, label: str, property: str = None):
+        """Returns Cypher query for index creation"""
+        index = MemgraphIndex(label, property)
+        return f"CREATE INDEX ON {index.to_cypher()}(id);"

--- a/gqlalchemy/utilities.py
+++ b/gqlalchemy/utilities.py
@@ -24,11 +24,24 @@ class NanValuesHandle(Enum):
 
 
 class NetworkXCypherConfig:
-    nan_handler = NanValuesHandle.THROW_EXCEPTION
+    def __init__(self, create_index: bool = False, nan_handler: NanValuesHandle = NanValuesHandle.THROW_EXCEPTION):
+        self._create_index = create_index
+        self._nan_handler = nan_handler
+
+    @property
+    def create_index(self) -> bool:
+        return self._create_index
+
+    @property
+    def nan_handler(self) -> NanValuesHandle:
+        return self._nan_handler
 
 
-def to_cypher_value(value: Any, config: NetworkXCypherConfig = NetworkXCypherConfig()) -> str:
+def to_cypher_value(value: Any, config: NetworkXCypherConfig = None) -> str:
     """Converts value to a valid openCypher type"""
+    if config is None:
+        config = NetworkXCypherConfig()
+
     value_type = type(value)
 
     if value_type == str and value.lower() == "null":
@@ -59,10 +72,11 @@ def to_cypher_value(value: Any, config: NetworkXCypherConfig = NetworkXCypherCon
     return f"'{value}'"
 
 
-def to_cypher_properties(
-    properties: Optional[Dict[str, Any]] = None, config: NetworkXCypherConfig = NetworkXCypherConfig()
-) -> str:
+def to_cypher_properties(properties: Optional[Dict[str, Any]] = None, config=None) -> str:
     """Converts properties to a openCypher key-value properties"""
+    if config is None:
+        config = NetworkXCypherConfig()
+
     if not properties:
         return ""
 

--- a/gqlalchemy/utilities.py
+++ b/gqlalchemy/utilities.py
@@ -36,7 +36,7 @@ def to_cypher_value(value: Any, config: NetworkXCypherConfig = NetworkXCypherCon
 
     if value_type == float and math.isnan(value):
         if config.nan_handler == NanValuesHandle.THROW_EXCEPTION:
-            raise MathException("Nan values are not allowed!")
+            raise NanException("Nan values are not allowed!")
 
         return "null"
 
@@ -83,5 +83,5 @@ def to_cypher_labels(labels: Union[str, List[str], None]) -> str:
     return ""
 
 
-class MathException(Exception):
+class NanException(Exception):
     pass

--- a/tests/intergration/test_networkx.py
+++ b/tests/intergration/test_networkx.py
@@ -19,6 +19,7 @@ import pytest
 from gqlalchemy import Memgraph
 from gqlalchemy.models import MemgraphIndex
 from gqlalchemy.transformations import nx_graph_to_memgraph_parallel, nx_to_cypher
+from gqlalchemy.utilities import NetworkXCypherConfig
 
 
 @pytest.fixture
@@ -79,7 +80,7 @@ def test_simple_index_nx_to_memgraph(memgraph: Memgraph):
         MemgraphIndex("L3", "id"),
     }
 
-    for query in nx_to_cypher(graph, True):
+    for query in nx_to_cypher(graph, NetworkXCypherConfig(create_index=True)):
         memgraph.execute(query)
     actual_indexes = set(memgraph.get_indexes())
 
@@ -129,7 +130,7 @@ def test_big_nx_to_memgraph_with_manual_index(memgraph: Memgraph, random_nx_grap
 @pytest.mark.timeout(60)
 @pytest.mark.slow
 def test_big_nx_to_memgraph(memgraph: Memgraph, random_nx_graph: nx.Graph):
-    for query in nx_to_cypher(random_nx_graph, create_index=True):
+    for query in nx_to_cypher(random_nx_graph, NetworkXCypherConfig(create_index=True)):
         memgraph.execute(query)
 
 

--- a/tests/memgraph/test_utilities.py
+++ b/tests/memgraph/test_utilities.py
@@ -21,7 +21,7 @@ from gqlalchemy.utilities import (
     to_cypher_labels,
     to_cypher_properties,
     to_cypher_value,
-    MathException,
+    NanException,
 )
 
 
@@ -79,14 +79,14 @@ def test_nan_value_default_config_throw_exception():
     config = NetworkXCypherConfig()
     properties = {"prop1": math.nan}
 
-    with pytest.raises(MathException):
+    with pytest.raises(NanException):
         to_cypher_properties(properties, config)
 
 
 def test_nan_value_no_config_throw_exception():
     properties = {"prop1": math.nan}
 
-    with pytest.raises(MathException):
+    with pytest.raises(NanException):
         to_cypher_properties(properties)
 
 

--- a/tests/memgraph/test_utilities.py
+++ b/tests/memgraph/test_utilities.py
@@ -91,8 +91,7 @@ def test_nan_value_no_config_throw_exception():
 
 
 def test_nan_value_remove_handler_yields_null():
-    config = NetworkXCypherConfig()
-    config.nan_handler = NanValuesHandle.REMOVE_PROPERTY
+    config = NetworkXCypherConfig(nan_handler=NanValuesHandle.REMOVE_PROPERTY)
 
     properties = {"prop1": math.nan}
     expected_properies = "{prop1: null}"

--- a/tests/memgraph/test_utilities.py
+++ b/tests/memgraph/test_utilities.py
@@ -13,7 +13,16 @@
 # limitations under the License.
 
 import pytest
-from gqlalchemy.utilities import to_cypher_labels, to_cypher_properties, to_cypher_value
+import math
+
+from gqlalchemy.utilities import (
+    NanValuesHandle,
+    NetworkXCypherConfig,
+    to_cypher_labels,
+    to_cypher_properties,
+    to_cypher_value,
+    MathException,
+)
 
 
 @pytest.mark.parametrize(
@@ -64,3 +73,29 @@ def test_to_cypher_labels_multiple_label():
     actual_cypher_label = to_cypher_labels(labels)
 
     assert actual_cypher_label == expected_cypher_label
+
+
+def test_nan_value_default_config_throw_exception():
+    config = NetworkXCypherConfig()
+    properties = {"prop1": math.nan}
+
+    with pytest.raises(MathException):
+        to_cypher_properties(properties, config)
+
+
+def test_nan_value_no_config_throw_exception():
+    properties = {"prop1": math.nan}
+
+    with pytest.raises(MathException):
+        to_cypher_properties(properties)
+
+
+def test_nan_value_remove_handler_yields_null():
+    config = NetworkXCypherConfig()
+    config.nan_handler = NanValuesHandle.REMOVE_PROPERTY
+
+    properties = {"prop1": math.nan}
+    expected_properies = "{prop1: null}"
+
+    actual_properties = to_cypher_properties(properties, config)
+    assert actual_properties == expected_properies

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 import networkx as nx
-from gqlalchemy.transformations import nx_to_cypher
+from gqlalchemy.transformations import nx_to_cypher, NoNetworkXConfigException, NetworkXCypherBuilder
+from gqlalchemy.utilities import NetworkXCypherConfig
 
 
 def test_nx_create_nodes():
@@ -159,8 +162,13 @@ def test_nx_create_edge_and_node_with_index():
         "MATCH (n:Label1:Label2 {id: 2}), (m:Label1 {id: 3}) CREATE (n)-[:TYPE2 {data: 'abc'}]->(m);",
     ]
 
-    actual_cypher_queries = list(nx_to_cypher(graph, True))
+    actual_cypher_queries = list(nx_to_cypher(graph, NetworkXCypherConfig(create_index=True)))
 
     assert actual_cypher_queries[0:3] == expected_cypher_queries[0:3]
     assert set(actual_cypher_queries[3:5]) == set(expected_cypher_queries[3:5])
     assert actual_cypher_queries[5:7] == expected_cypher_queries[5:7]
+
+
+def test_creating_builder_with_no_config_throws_exception():
+    with pytest.raises(NoNetworkXConfigException):
+        NetworkXCypherBuilder(None)


### PR DESCRIPTION
Added additional configuration to handle NaN values when converting from nxGraph to Cypher queries. The default configuration raises NanException. Additional handle for Nan values is provided - yielding null if nan occurs, therefore the property will not be added when injecting queries to Memgraph.