### PR TITLE
add match support for objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,44 @@ As we can see, the example above can be error-prone, because we do not have abst
 Now, rewrite the exact same query by using the functionality of gqlalchemys query builder..
 
 ```python
-
 from gqlalchemy import Match, Memgraph
 
 memgraph = Memgraph()
 
-results = Match().node("Node",variable="from")
-                 .to("Connection")
-                 .node("Node",variable="to")
+results = Match().node("Node",variable="from")\
+                 .to("Connection")\
+                 .node("Node",variable="to")\
                  .execute()
 
 for result in results:
     print(result['from'])
     print(result['to'])
+```
+
+An example using the Node and Relationship classes:
+```python
+from gqlalchemy import Memgraph, Node, Relationship, Match
+
+memgraph = Memgraph("127.0.0.1", 7687)
+
+memgraph.execute("CREATE (:Node {id: 1})-[:RELATED_TO {id: 1}]->(:Node {id: 2})")
+
+# the first argument should be set by Memgraph
+a = Node(1, ["Node"], {'id': 1})
+b = Node(2, ["Node"], {'id': 2})
+r = Relationship(1, "RELATED_TO", 1, 2, {'id': 1})
+
+result = list(
+    Match(memgraph.new_connection())
+    .node(variable="a", node=a)
+    .to(variable="r", relationship=r)
+    .node(variable="b", node=b)
+    .execute()
+)[0]
+
+print(result['a'])
+print(result['b'])
+print(result['r'])
 ```
 
 ## License

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -159,13 +159,18 @@ class Match:
         self,
         labels: Union[str, List[str], None] = "",
         variable: Optional[str] = None,
+        node: Optional["Node"] = None,
         **kwargs,
     ) -> "Match":
-        labels_str = to_cypher_labels(labels)
-        properties_str = to_cypher_properties(kwargs)
-
         if not self._is_linking_valid_with_query(MatchTypes.NODE):
             raise InvalidMatchChainException()
+
+        if node is None:
+            labels_str = to_cypher_labels(labels)
+            properties_str = to_cypher_properties(kwargs)
+        else:
+            labels_str = to_cypher_labels(node.labels)
+            properties_str = to_cypher_properties(node.properties)
 
         self._query.append(NodePartialQuery(variable, labels_str, properties_str))
 
@@ -176,14 +181,18 @@ class Match:
         edge_label: Optional[str] = "",
         directed: Optional[bool] = True,
         variable: Optional[str] = None,
+        relationship: Optional["Relationship"] = None,
         **kwargs,
     ) -> "Match":
-
         if not self._is_linking_valid_with_query(MatchTypes.EDGE):
             raise InvalidMatchChainException()
 
-        labels_str = to_cypher_labels(edge_label)
-        properties_str = to_cypher_properties(kwargs)
+        if relationship is None:
+            labels_str = to_cypher_labels(edge_label)
+            properties_str = to_cypher_properties(kwargs)
+        else:
+            labels_str = to_cypher_labels(relationship.type)
+            properties_str = to_cypher_properties(relationship.properties)
 
         self._query.append(EdgePartialQuery(variable, labels_str, properties_str, bool(directed)))
 

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 
 from .memgraph import Connection, Memgraph
 from .utilities import to_cypher_labels, to_cypher_properties, to_cypher_value
+from .models import Node, Relationship
 
 
 class MatchTypes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
     "Josip Mrden <josip.mrden@memgraph.com>",
     "Josip Matak <josip.matak@memgraph.com>",
     "Marko Budiselic <marko.budiselic@memgraph.com>",
+    "Mislav Vuletić <mislav.vuletic@memgraph.com>",
 ]
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This PR adds support for querying Memgraph using Node and Relationship objects:

Here's an example
```python
from gqlalchemy import Memgraph, Node, Relationship, Match

memgraph = Memgraph("127.0.0.1", 7687)

memgraph.execute("CREATE (:Node {id: 1})-[:RELATED_TO {id: 1}]->(:Node {id: 2})")

# the first argument should be set by Memgraph
a = Node(1, ["Node"], {'id': 1})
b = Node(2, ["Node"], {'id': 2})
r = Relationship(1, "RELATED_TO", 1, 2, {'id': 1})

result = list(
    Match(memgraph.new_connection())
    .node(variable="a", node=a)
    .to(variable="r", relationship=r)
    .node(variable="b", node=b)
    .execute()
)[0]

print(result['a'])
print(result['b'])
print(result['r'])
```