### PR TITLE
Add custom string method to query builder

### DIFF
--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -329,13 +329,13 @@ class SkipPartialQuery(PartialQuery):
 
 
 class AddStringPartialQuery(PartialQuery):
-    def __init__(self, custom_string: str):
+    def __init__(self, custom_cypher: str):
         super().__init__(DeclarativeBaseTypes.SKIP)
 
-        self.custom_string = custom_string
+        self.custom_cypher = custom_cypher
 
     def construct_query(self) -> str:
-        return f"{self.custom_string}"
+        return f"{self.custom_cypher}"
 
 
 class DeclarativeBase(ABC):
@@ -502,8 +502,8 @@ class DeclarativeBase(ABC):
 
         return self
 
-    def add_string(self, custom_string: str) -> "DeclarativeBase":
-        self._query.append(AddStringPartialQuery(custom_string))
+    def add_custom_cypher(self, custom_cypher: str) -> "DeclarativeBase":
+        self._query.append(AddStringPartialQuery(custom_cypher))
 
         return self
 

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -328,6 +328,16 @@ class SkipPartialQuery(PartialQuery):
         return f" SKIP {self.integer_expression} "
 
 
+class AddStringPartialQuery(PartialQuery):
+    def __init__(self, custom_string: str):
+        super().__init__(DeclarativeBaseTypes.SKIP)
+
+        self.custom_string = custom_string
+
+    def construct_query(self) -> str:
+        return f"{self.custom_string}"
+
+
 class DeclarativeBase(ABC):
     def __init__(self, connection: Optional[Union[Connection, Memgraph]] = None):
         self._query: List[Any] = []
@@ -489,6 +499,11 @@ class DeclarativeBase(ABC):
 
     def skip(self, integer_expression: str) -> "DeclarativeBase":
         self._query.append(SkipPartialQuery(integer_expression))
+
+        return self
+
+    def add_string(self, custom_string: str) -> "DeclarativeBase":
+        self._query.append(AddStringPartialQuery(custom_string))
 
         return self
 

--- a/tests/memgraph/test_query_builder.py
+++ b/tests/memgraph/test_query_builder.py
@@ -442,7 +442,9 @@ class TestMatch:
         mock.assert_called_with(expected_query)
 
     def test_add_string_partial(self):
-        query_builder = match().node("Node1", variable="n").to("TO", variable="e").add_string("(m:L2) ").return_()
+        query_builder = (
+            match().node("Node1", variable="n").to("TO", variable="e").add_custom_cypher("(m:L2) ").return_()
+        )
         expected_query = " MATCH (n:Node1)-[e:TO]->(m:L2) RETURN * "
 
         with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
@@ -451,7 +453,7 @@ class TestMatch:
         mock.assert_called_with(expected_query)
 
     def test_add_string_complete(self):
-        query_builder = QueryBuilder().add_string("MATCH (n) RETURN n")
+        query_builder = QueryBuilder().add_custom_cypher("MATCH (n) RETURN n")
         expected_query = "MATCH (n) RETURN n"
 
         with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:

--- a/tests/memgraph/test_query_builder.py
+++ b/tests/memgraph/test_query_builder.py
@@ -440,3 +440,21 @@ class TestMatch:
             query_builder.execute()
 
         mock.assert_called_with(expected_query)
+
+    def test_add_string_partial(self):
+        query_builder = match().node("Node1", variable="n").to("TO", variable="e").add_string("(m:L2) ").return_()
+        expected_query = " MATCH (n:Node1)-[e:TO]->(m:L2) RETURN * "
+
+        with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+            query_builder.execute()
+
+        mock.assert_called_with(expected_query)
+
+    def test_add_string_complete(self):
+        query_builder = QueryBuilder().add_string("MATCH (n) RETURN n")
+        expected_query = "MATCH (n) RETURN n"
+
+        with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+            query_builder.execute()
+
+        mock.assert_called_with(expected_query)


### PR DESCRIPTION
The `add_custom_cypher()` method enables the user to add any string to the query builder. It is needed because there are functionalities that still need to be implemented inside the query builder.