### PR TITLE
[develop < T0013-GA] Create trigger without ON

### DIFF
--- a/gqlalchemy/memgraph.py
+++ b/gqlalchemy/memgraph.py
@@ -200,13 +200,38 @@ class Memgraph:
         self.execute(query)
 
     def get_triggers(self) -> List[str]:
-        """Creates a trigger"""
-        return list(self.execute_and_fetch("SHOW TRIGGERS;"))
+        """Returns a list of all database triggers"""
+        triggers_list = list(self.execute_and_fetch("SHOW TRIGGERS;"))
+        memgraph_triggers_list = []
+        for trigger in triggers_list:
+            event_type = trigger["event type"]
+            event_object = None
+
+            if event_type == "ANY":
+                event_type = None
+            elif len(event_type.split()) > 1:
+                [event_object, event_type] = [part for part in event_type.split()]
+
+            memgraph_triggers_list.append(
+                MemgraphTrigger(
+                    name=trigger["trigger name"],
+                    event_type=event_type,
+                    event_object=event_object,
+                    execution_phase=trigger["phase"].split()[0],
+                    statement=trigger["statement"],
+                )
+            )
+        return memgraph_triggers_list
 
     def drop_trigger(self, trigger) -> None:
         """Drop a trigger"""
         query = f"DROP TRIGGER {trigger.name};"
         self.execute(query)
+
+    def drop_triggers(self) -> None:
+        """Drops all triggers in the database"""
+        for trigger in self.get_triggers():
+            self.drop_trigger(trigger)
 
     def _get_cached_connection(self) -> Connection:
         """Returns cached connection if it exists, creates it otherwise"""

--- a/gqlalchemy/models.py
+++ b/gqlalchemy/models.py
@@ -32,11 +32,18 @@ class TriggerEventType:
     UPDATE = "UPDATE"
     DELETE = "DELETE"
 
+    @classmethod
+    def list(cls):
+        return [cls.CREATE, cls.UPDATE, cls.DELETE]
+
 
 class TriggerEventObject:
-    ALL = ""
     NODE = "()"
     RELATIONSHIP = "-->"
+
+    @classmethod
+    def list(cls):
+        return [cls.NODE, cls.RELATIONSHIP]
 
 
 class TriggerExecutionPhase:
@@ -151,18 +158,20 @@ class MemgraphPulsarStream(MemgraphStream):
 @dataclass(frozen=True, eq=True)
 class MemgraphTrigger:
     name: str
-    event_type: TriggerEventType
-    event_object: TriggerEventObject
     execution_phase: TriggerExecutionPhase
     statement: str
+    event_type: Optional[TriggerEventType] = None
+    event_object: Optional[TriggerEventObject] = None
 
     def to_cypher(self) -> str:
         """Converts a Trigger to a cypher clause."""
-        query = f"CREATE TRIGGER {self.name} ON " + (
-            f"{self.event_type} "
-            if self.event_object is TriggerEventObject.ALL
-            else f"{self.event_object} {self.event_type} "
-        )
+        query = f"CREATE TRIGGER {self.name} "
+        if self.event_type in TriggerEventType.list():
+            query += f"ON " + (
+                f"{self.event_object} {self.event_type} "
+                if self.event_object in TriggerEventObject.list()
+                else f"{self.event_type} "
+            )
         query += f"{self.execution_phase} COMMIT EXECUTE "
         query += f"{self.statement};"
         return query


### PR DESCRIPTION
- [x] Change description of `get_triggers` method
- [x] Change `get_triggers` procedure to return list of `MemgraphTrigger` objects
- [x] Implement `drop_triggers` procedure that drops all triggers in the database (with the change of the `get_triggers` procedure, `drop_triggers` can use `drop_trigger` procedure)
- [x] Remove `"ALL"` from the `models.py` - triggers in Memgraph have this case as `"ANY"` and here it's just an empty string, I think we can handle all this without the `"ALL"` constant
- [x] Add list class methods to `TriggerEventType` and `TriggerEventObject` classes, for easier type check
- [x] Change `event_type` and `event_object` properties in `MemgraphTrigger` to be optional - as in our Cypher grammar
- [x] Change `to_cypher` procedure accordingly
- [x] Add tests for all cases and fix pytest fixture to drop all triggers before and after test execution