### PR TITLE
[develop < T0039-GA] Change where procedure in query builder

### DIFF
--- a/gqlalchemy/exceptions.py
+++ b/gqlalchemy/exceptions.py
@@ -34,6 +34,19 @@ db = Memgraph()
 SQLitePropertyDatabase("path-to-sqlite-db", db)
 """
 
+OPERATOR_MISSING_IN_WHERE = """
+Can't create WHERE query without providing the 'operator' keyword argument. Possible values for operator are '=', '<>', '!=', '<', '>', '<=', '>=', ':'.
+"""
+
+LITERAL_AND_EXPRESSION_MISSING_IN_WHERE = """
+Can't create WHERE query without providing either 'literal' or 'expression' keyword arguments, that can be literals, labels or properties.
+"""
+
+EXTRA_KEYWORD_ARGUMENTS_IN_WHERE = """
+Can't create WHERE query with extra keyword arguments:
+Please provide a value to either 'literal' or 'expression' keyword arguments."
+"""
+
 
 class GQLAlchemyWarning(Warning):
     pass
@@ -66,3 +79,21 @@ class GQLAlchemyOnDiskPropertyDatabaseNotDefinedError(GQLAlchemyError):
     def __init__(self):
         super().__init__()
         self.message = ON_DISK_PROPERTY_DATABASE_NOT_DEFINED_ERROR
+
+
+class GQLAlchemyOperatorMissingInWhere(GQLAlchemyError):
+    def __init__(self):
+        super().__init__()
+        self.message = OPERATOR_MISSING_IN_WHERE
+
+
+class GQLAlchemyLiteralAndExpressionMissingInWhere(GQLAlchemyError):
+    def __init__(self):
+        super().__init__()
+        self.message = LITERAL_AND_EXPRESSION_MISSING_IN_WHERE
+
+
+class GQLAlchemyExtraKeywordArgumentsInWhere(GQLAlchemyError):
+    def __init__(self):
+        super().__init__()
+        self.message = EXTRA_KEYWORD_ARGUMENTS_IN_WHERE

--- a/gqlalchemy/exceptions.py
+++ b/gqlalchemy/exceptions.py
@@ -34,10 +34,6 @@ db = Memgraph()
 SQLitePropertyDatabase("path-to-sqlite-db", db)
 """
 
-OPERATOR_MISSING_IN_WHERE = """
-Can't create WHERE query without providing the 'operator' keyword argument. Possible values for operator are '=', '<>', '!=', '<', '>', '<=', '>=', ':'.
-"""
-
 LITERAL_AND_EXPRESSION_MISSING_IN_WHERE = """
 Can't create WHERE query without providing either 'literal' or 'expression' keyword arguments, that can be literals, labels or properties.
 """
@@ -79,12 +75,6 @@ class GQLAlchemyOnDiskPropertyDatabaseNotDefinedError(GQLAlchemyError):
     def __init__(self):
         super().__init__()
         self.message = ON_DISK_PROPERTY_DATABASE_NOT_DEFINED_ERROR
-
-
-class GQLAlchemyOperatorMissingInWhere(GQLAlchemyError):
-    def __init__(self):
-        super().__init__()
-        self.message = OPERATOR_MISSING_IN_WHERE
 
 
 class GQLAlchemyLiteralAndExpressionMissingInWhere(GQLAlchemyError):

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -470,45 +470,23 @@ class DeclarativeBase(ABC):
 
         return self
 
-    def _build_where_query(
-        self, statement: str, item: str, operator: str, separator: str, literal: Any, expression: Any
-    ):
-        """Builds parts of a WHERE Cypher query divided by the boolean operators.
+    def _build_where_query(self, statement: str, item: str, operator: str, literal: Any, expression: str):
+        """Builds parts of a WHERE Cypher query divided by the boolean operators."""
 
-        Args:
-            item: A string representing variable or property.
-            operator: A string representing the operator.
-            literal: A value that will be converted to Cypher value, such as int, float, string, etc.
-            expression: A node label or property that won't be converted to Cypher value (no additional quotes will be added).
-
-        Raises:
-            GQLAlchemyLiteralAndExpressionMissingInWhere: Raises an error when neither literal nor expression keyword arguments were provided.
-            GQLAlchemyExtraKeywordArgumentsInWhere: Raises an error when both literal and expression keyword arguments were provided.
-
-        Returns:
-            self: A partial Cypher query built from the given parameters.
-        """
-
-        if statement == WhereConditionConstants.WHERE:
-            clause = WhereConditionConstants.WHERE
-        elif statement == WhereConditionConstants.AND:
-            clause = WhereConditionConstants.AND
-        elif statement == WhereConditionConstants.OR:
-            clause = WhereConditionConstants.OR
-        elif statement == WhereConditionConstants.XOR:
-            clause = WhereConditionConstants.XOR
-
+        separator = "" if operator == ":" else " "
         if literal is None:
             if expression is None:
                 raise GQLAlchemyLiteralAndExpressionMissingInWhere
-            self._query.append(WhereConditionPartialQuery(clause, separator.join([item, operator, expression])))
+
+            self._query.append(WhereConditionPartialQuery(statement, separator.join([item, operator, expression])))
+
             return self
 
         if expression is not None:
             raise GQLAlchemyExtraKeywordArgumentsInWhere
 
         self._query.append(
-            WhereConditionPartialQuery(clause, separator.join([item, operator, to_cypher_value(literal)]))
+            WhereConditionPartialQuery(statement, separator.join([item, operator, to_cypher_value(literal)]))
         )
 
         return self
@@ -524,6 +502,10 @@ class DeclarativeBase(ABC):
             literal: A value that will be converted to Cypher value, such as int, float, string, etc.
             expression: A node label or property that won't be converted to Cypher value (no additional quotes will be added).
 
+        Raises:
+            GQLAlchemyLiteralAndExpressionMissingInWhere: Raises an error when neither literal nor expression keyword arguments were provided.
+            GQLAlchemyExtraKeywordArgumentsInWhere: Raises an error when both literal and expression keyword arguments were provided.
+
         Returns:
             self: A partial Cypher query built from the given parameters.
         """
@@ -531,11 +513,9 @@ class DeclarativeBase(ABC):
         # item: variable | property
         # expression: label | property
 
-        literal = kwargs.get("literal")
-        expression = kwargs.get("expression")
-        separator = "" if operator == ":" else " "
-
-        return self._build_where_query(WhereConditionConstants.WHERE, item, operator, separator, literal, expression)
+        return self._build_where_query(
+            WhereConditionConstants.WHERE, item, operator, kwargs.get("literal"), kwargs.get("expression")
+        )
 
     def and_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates an AND statement as a part of WHERE Cypher partial query.
@@ -551,12 +531,9 @@ class DeclarativeBase(ABC):
         Returns:
             self: A partial Cypher query built from the given parameters.
         """
-
-        literal = kwargs.get("literal")
-        expression = kwargs.get("expression")
-        separator = "" if operator == ":" else " "
-
-        return self._build_where_query(WhereConditionConstants.AND, item, operator, separator, literal, expression)
+        return self._build_where_query(
+            WhereConditionConstants.AND, item, operator, kwargs.get("literal"), kwargs.get("expression")
+        )
 
     def or_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates an OR statement as a part of WHERE Cypher partial query.
@@ -573,11 +550,9 @@ class DeclarativeBase(ABC):
             self: A partial Cypher query built from the given parameters.
         """
 
-        literal = kwargs.get("literal")
-        expression = kwargs.get("expression")
-        separator = "" if operator == ":" else " "
-
-        return self._build_where_query(WhereConditionConstants.OR, item, operator, separator, literal, expression)
+        return self._build_where_query(
+            WhereConditionConstants.OR, item, operator, kwargs.get("literal"), kwargs.get("expression")
+        )
 
     def xor_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates an XOR statement as a part of WHERE Cypher partial query.
@@ -594,11 +569,9 @@ class DeclarativeBase(ABC):
             self: A partial Cypher query built from the given parameters.
         """
 
-        literal = kwargs.get("literal")
-        expression = kwargs.get("expression")
-        separator = "" if operator == ":" else " "
-
-        return self._build_where_query(WhereConditionConstants.XOR, item, operator, separator, literal, expression)
+        return self._build_where_query(
+            WhereConditionConstants.XOR, item, operator, kwargs.get("literal"), kwargs.get("expression")
+        )
 
     def unwind(self, list_expression: str, variable: str) -> "DeclarativeBase":
         """Creates a UNWIND statement Cypher partial query."""

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -19,7 +19,10 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 from .memgraph import Connection, Memgraph
 from .utilities import to_cypher_labels, to_cypher_properties, to_cypher_value
 from .models import Node, Relationship
-from .exceptions import GQLAlchemyError
+from .exceptions import (
+    GQLAlchemyLiteralAndExpressionMissingInWhere,
+    GQLAlchemyExtraKeywordArgumentsInWhere,
+)
 
 
 class DeclarativeBaseTypes:
@@ -477,28 +480,15 @@ class DeclarativeBase(ABC):
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        if item is None:
-            raise GQLAlchemyError(
-                f"Create WHERE query GQLAlchemy error on lhs:"
-                + " Please provide a value to the 'item' keyword argument,"
-                + " that is a variable or a property."
-            )
         if literal is None:
             if expression is None:
-                raise GQLAlchemyError(
-                    f"Create WHERE query GQLAlchemy error on rhs:"
-                    + " Please provide a value to either 'literal' or 'expression' keyword arguments,"
-                    + " that can be literals, labels or properties."
-                )
+                raise GQLAlchemyLiteralAndExpressionMissingInWhere
             self._query.append(
                 WhereConditionPartialQuery(WhereConditionConstants.WHERE, separator.join([item, operator, expression]))
             )
             return self
         if expression is not None:
-            raise GQLAlchemyError(
-                f"Create WHERE query GQLAlchemy error extra values:"
-                + " Please provide a value to only one of the 'literal' and 'expression' keyword arguments."
-            )
+            raise GQLAlchemyExtraKeywordArgumentsInWhere
 
         self._query.append(
             WhereConditionPartialQuery(
@@ -509,34 +499,20 @@ class DeclarativeBase(ABC):
 
     def and_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates an AND (expression) statement Cypher partial query."""
-        separator = "" if operator == ":" else " "
 
         literal = kwargs.get("literal")
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        if item is None:
-            raise GQLAlchemyError(
-                f"Create AND WHERE query GQLAlchemy error on lhs:"
-                + " Please provide a value to the 'item' keyword argument,"
-                + " that is a variable or a property."
-            )
         if literal is None:
             if expression is None:
-                raise GQLAlchemyError(
-                    f"Create AND WHERE query GQLAlchemy error on rhs:"
-                    + " Please provide a value to either 'literal' or 'expression' keyword arguments,"
-                    + " that can be literals, labels or properties."
-                )
+                raise GQLAlchemyLiteralAndExpressionMissingInWhere
             self._query.append(
                 WhereConditionPartialQuery(WhereConditionConstants.AND, separator.join([item, operator, expression]))
             )
             return self
         if expression is not None:
-            raise GQLAlchemyError(
-                f"Create AND WHERE query GQLAlchemy error extra values:"
-                + " Please provide a value to only one of the 'literal' and 'expression' keyword arguments."
-            )
+            raise GQLAlchemyExtraKeywordArgumentsInWhere
 
         self._query.append(
             WhereConditionPartialQuery(
@@ -548,34 +524,19 @@ class DeclarativeBase(ABC):
     def or_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates an OR (expression) statement Cypher partial query."""
 
-        separator = "" if operator == ":" else " "
-
         literal = kwargs.get("literal")
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        if item is None:
-            raise GQLAlchemyError(
-                f"Create OR WHERE query GQLAlchemy error on lhs:"
-                + " Please provide a value to the 'item' keyword argument,"
-                + " that is a variable or a property."
-            )
         if literal is None:
             if expression is None:
-                raise GQLAlchemyError(
-                    f"Create OR WHERE query GQLAlchemy error on rhs:"
-                    + " Please provide a value to either 'literal' or 'expression' keyword arguments,"
-                    + " that can be literals, labels or properties."
-                )
+                raise GQLAlchemyLiteralAndExpressionMissingInWhere
             self._query.append(
                 WhereConditionPartialQuery(WhereConditionConstants.OR, separator.join([item, operator, expression]))
             )
             return self
         if expression is not None:
-            raise GQLAlchemyError(
-                f"Create OR WHERE query GQLAlchemy error extra values:"
-                + " Please provide a value to only one of the 'literal' and 'expression' keyword arguments."
-            )
+            raise GQLAlchemyExtraKeywordArgumentsInWhere
 
         self._query.append(
             WhereConditionPartialQuery(
@@ -587,34 +548,19 @@ class DeclarativeBase(ABC):
     def xor_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates a XOR (expression) statement Cypher partial query."""
 
-        separator = "" if operator == ":" else " "
-
         literal = kwargs.get("literal")
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        if item is None:
-            raise GQLAlchemyError(
-                f"Create XOR WHERE query GQLAlchemy error on lhs:"
-                + " Please provide a value to the 'item' keyword argument,"
-                + " that is a variable or a property."
-            )
         if literal is None:
             if expression is None:
-                raise GQLAlchemyError(
-                    f"Create XOR WHERE query GQLAlchemy error on rhs:"
-                    + " Please provide a value to either 'literal' or 'expression' keyword arguments,"
-                    + " that can be literals, labels or properties."
-                )
+                raise GQLAlchemyLiteralAndExpressionMissingInWhere
             self._query.append(
                 WhereConditionPartialQuery(WhereConditionConstants.XOR, separator.join([item, operator, expression]))
             )
             return self
         if expression is not None:
-            raise GQLAlchemyError(
-                f"Create XOR WHERE query GQLAlchemy error extra values:"
-                + " Please provide a value to only one of the 'literal' and 'expression' keyword arguments."
-            )
+            raise GQLAlchemyExtraKeywordArgumentsInWhere
 
         self._query.append(
             WhereConditionPartialQuery(

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -501,15 +501,14 @@ class DeclarativeBase(ABC):
         """Creates a WHERE statement Cypher partial query.
 
         Args:
-            item: A string representing variable or property. operator: A string
-            representing the operator. literal: A value that will be converted
-            to Cypher value, such as int, float, string, etc. expression: A node
-            label or property that won't be converted to Cypher value (no
-            additional quotes will be added).
-        Raises: GQLAlchemyLiteralAndExpressionMissingInWhere: Raises an error
-        when neither literal nor expression keyword arguments were provided.
-        GQLAlchemyExtraKeywordArgumentsInWhere: Raises an error when both
-        literal and expression keyword arguments were provided.
+            item: A string representing variable or property.
+            operator: A string representing the operator.
+            literal: A value that will be converted to Cypher value, such as int, float, string, etc.
+            expression: A node label or property that won't be converted to Cypher value (no additional quotes will be added).
+
+        Raises:
+            GQLAlchemyLiteralAndExpressionMissingInWhere: Raises an error when neither literal nor expression keyword arguments were provided.
+            GQLAlchemyExtraKeywordArgumentsInWhere: Raises an error when both literal and expression keyword arguments were provided.
         """
         # WHERE item operator (literal | expression)
         # item: variable | property

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 from .memgraph import Connection, Memgraph
 from .utilities import to_cypher_labels, to_cypher_properties, to_cypher_value
 from .models import Node, Relationship
+from .exceptions import GQLAlchemyError
 
 
 class DeclarativeBaseTypes:
@@ -466,48 +467,160 @@ class DeclarativeBase(ABC):
 
         return self
 
-    def where(self, item: str, operator: str, value: Any) -> "DeclarativeBase":
+    def where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates a WHERE statement Cypher partial query."""
+        # WHERE item operator (literal | expression)
+        # item: variable | property
+        # expression: label | property
+
+        literal = kwargs.get("literal")
+        expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
+
+        if item is None:
+            raise GQLAlchemyError(
+                f"Create WHERE query GQLAlchemy error on lhs:"
+                + " Please provide a value to the 'item' keyword argument,"
+                + " that is a variable or a property."
+            )
+        if literal is None:
+            if expression is None:
+                raise GQLAlchemyError(
+                    f"Create WHERE query GQLAlchemy error on rhs:"
+                    + " Please provide a value to either 'literal' or 'expression' keyword arguments,"
+                    + " that can be literals, labels or properties."
+                )
+            self._query.append(
+                WhereConditionPartialQuery(WhereConditionConstants.WHERE, separator.join([item, operator, expression]))
+            )
+            return self
+        if expression is not None:
+            raise GQLAlchemyError(
+                f"Create WHERE query GQLAlchemy error extra values:"
+                + " Please provide a value to only one of the 'literal' and 'expression' keyword arguments."
+            )
+
         self._query.append(
             WhereConditionPartialQuery(
-                WhereConditionConstants.WHERE, separator.join([item, operator, to_cypher_value(value)])
+                WhereConditionConstants.WHERE, separator.join([item, operator, to_cypher_value(literal)])
             )
         )
-
         return self
 
-    def and_where(self, item: str, operator: str, value: Any) -> "DeclarativeBase":
-        """Creates a AND (expression) statement Cypher partial query."""
+    def and_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
+        """Creates an AND (expression) statement Cypher partial query."""
         separator = "" if operator == ":" else " "
+
+        literal = kwargs.get("literal")
+        expression = kwargs.get("expression")
+        separator = "" if operator == ":" else " "
+
+        if item is None:
+            raise GQLAlchemyError(
+                f"Create AND WHERE query GQLAlchemy error on lhs:"
+                + " Please provide a value to the 'item' keyword argument,"
+                + " that is a variable or a property."
+            )
+        if literal is None:
+            if expression is None:
+                raise GQLAlchemyError(
+                    f"Create AND WHERE query GQLAlchemy error on rhs:"
+                    + " Please provide a value to either 'literal' or 'expression' keyword arguments,"
+                    + " that can be literals, labels or properties."
+                )
+            self._query.append(
+                WhereConditionPartialQuery(WhereConditionConstants.AND, separator.join([item, operator, expression]))
+            )
+            return self
+        if expression is not None:
+            raise GQLAlchemyError(
+                f"Create AND WHERE query GQLAlchemy error extra values:"
+                + " Please provide a value to only one of the 'literal' and 'expression' keyword arguments."
+            )
+
         self._query.append(
             WhereConditionPartialQuery(
-                WhereConditionConstants.AND, separator.join([item, operator, to_cypher_value(value)])
+                WhereConditionConstants.AND, separator.join([item, operator, to_cypher_value(literal)])
             )
         )
-
         return self
 
-    def or_where(self, item: str, operator: str, value: Any) -> "DeclarativeBase":
-        """Creates a OR (expression) statement Cypher partial query."""
+    def or_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
+        """Creates an OR (expression) statement Cypher partial query."""
+
         separator = "" if operator == ":" else " "
+
+        literal = kwargs.get("literal")
+        expression = kwargs.get("expression")
+        separator = "" if operator == ":" else " "
+
+        if item is None:
+            raise GQLAlchemyError(
+                f"Create OR WHERE query GQLAlchemy error on lhs:"
+                + " Please provide a value to the 'item' keyword argument,"
+                + " that is a variable or a property."
+            )
+        if literal is None:
+            if expression is None:
+                raise GQLAlchemyError(
+                    f"Create OR WHERE query GQLAlchemy error on rhs:"
+                    + " Please provide a value to either 'literal' or 'expression' keyword arguments,"
+                    + " that can be literals, labels or properties."
+                )
+            self._query.append(
+                WhereConditionPartialQuery(WhereConditionConstants.OR, separator.join([item, operator, expression]))
+            )
+            return self
+        if expression is not None:
+            raise GQLAlchemyError(
+                f"Create OR WHERE query GQLAlchemy error extra values:"
+                + " Please provide a value to only one of the 'literal' and 'expression' keyword arguments."
+            )
+
         self._query.append(
             WhereConditionPartialQuery(
-                WhereConditionConstants.OR, separator.join([item, operator, to_cypher_value(value)])
+                WhereConditionConstants.OR, separator.join([item, operator, to_cypher_value(literal)])
             )
         )
-
         return self
 
-    def xor_where(self, property: str, operator: str, value: Any) -> "DeclarativeBase":
+    def xor_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates a XOR (expression) statement Cypher partial query."""
+
         separator = "" if operator == ":" else " "
+
+        literal = kwargs.get("literal")
+        expression = kwargs.get("expression")
+        separator = "" if operator == ":" else " "
+
+        if item is None:
+            raise GQLAlchemyError(
+                f"Create XOR WHERE query GQLAlchemy error on lhs:"
+                + " Please provide a value to the 'item' keyword argument,"
+                + " that is a variable or a property."
+            )
+        if literal is None:
+            if expression is None:
+                raise GQLAlchemyError(
+                    f"Create XOR WHERE query GQLAlchemy error on rhs:"
+                    + " Please provide a value to either 'literal' or 'expression' keyword arguments,"
+                    + " that can be literals, labels or properties."
+                )
+            self._query.append(
+                WhereConditionPartialQuery(WhereConditionConstants.XOR, separator.join([item, operator, expression]))
+            )
+            return self
+        if expression is not None:
+            raise GQLAlchemyError(
+                f"Create XOR WHERE query GQLAlchemy error extra values:"
+                + " Please provide a value to only one of the 'literal' and 'expression' keyword arguments."
+            )
+
         self._query.append(
             WhereConditionPartialQuery(
-                WhereConditionConstants.XOR, separator.join([property, operator, to_cypher_value(value)])
+                WhereConditionConstants.XOR, separator.join([item, operator, to_cypher_value(literal)])
             )
         )
-
         return self
 
     def unwind(self, list_expression: str, variable: str) -> "DeclarativeBase":

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -478,7 +478,7 @@ class DeclarativeBase(ABC):
         if value is None:
             if literal is None:
                 raise GQLAlchemyLiteralAndExpressionMissingInWhere
-            
+
             value = to_cypher_value(literal)
         elif literal is not None:
             raise GQLAlchemyExtraKeywordArgumentsInWhere
@@ -486,9 +486,7 @@ class DeclarativeBase(ABC):
         self._query.append(
             WhereConditionPartialQuery(
                 statement,
-                ("" if operator == ":" else " ").join(
-                    [item, operator, value]
-                ),
+                ("" if operator == ":" else " ").join([item, operator, value]),
             )
         )
 
@@ -516,9 +514,7 @@ class DeclarativeBase(ABC):
         # item: variable | property
         # expression: label | property
 
-        return self._build_where_query(
-            WhereConditionConstants.WHERE, item, operator, **kwargs
-        )
+        return self._build_where_query(WhereConditionConstants.WHERE, item, operator, **kwargs)
 
     def and_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates an AND statement as a part of WHERE Cypher partial query.
@@ -534,9 +530,7 @@ class DeclarativeBase(ABC):
         Returns:
             self: A partial Cypher query built from the given parameters.
         """
-        return self._build_where_query(
-            WhereConditionConstants.AND, item, operator, **kwargs
-        )
+        return self._build_where_query(WhereConditionConstants.AND, item, operator, **kwargs)
 
     def or_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates an OR statement as a part of WHERE Cypher partial query.
@@ -553,9 +547,7 @@ class DeclarativeBase(ABC):
             self: A partial Cypher query built from the given parameters.
         """
 
-        return self._build_where_query(
-            WhereConditionConstants.OR, item, operator, **kwargs
-        )
+        return self._build_where_query(WhereConditionConstants.OR, item, operator, **kwargs)
 
     def xor_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates an XOR statement as a part of WHERE Cypher partial query.
@@ -572,9 +564,7 @@ class DeclarativeBase(ABC):
             self: A partial Cypher query built from the given parameters.
         """
 
-        return self._build_where_query(
-            WhereConditionConstants.XOR, item, operator, **kwargs
-        )
+        return self._build_where_query(WhereConditionConstants.XOR, item, operator, **kwargs)
 
     def unwind(self, list_expression: str, variable: str) -> "DeclarativeBase":
         """Creates a UNWIND statement Cypher partial query."""

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -470,8 +470,47 @@ class DeclarativeBase(ABC):
 
         return self
 
+    def create_where_query(
+        self, statement: str, item: str, operator: str, separator: str, literal: Any, expression: Any
+    ):
+
+        if statement == WhereConditionConstants.WHERE:
+            clause = WhereConditionConstants.WHERE
+        elif statement == WhereConditionConstants.AND:
+            clause = WhereConditionConstants.AND
+        elif statement == WhereConditionConstants.OR:
+            clause = WhereConditionConstants.OR
+        elif statement == WhereConditionConstants.XOR:
+            clause = WhereConditionConstants.XOR
+
+        if literal is None:
+            if expression is None:
+                raise GQLAlchemyLiteralAndExpressionMissingInWhere
+            self._query.append(WhereConditionPartialQuery(clause, separator.join([item, operator, expression])))
+            return self
+
+        if expression is not None:
+            raise GQLAlchemyExtraKeywordArgumentsInWhere
+
+        self._query.append(
+            WhereConditionPartialQuery(clause, separator.join([item, operator, to_cypher_value(literal)]))
+        )
+        return self
+
     def where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
-        """Creates a WHERE statement Cypher partial query."""
+        """Creates a WHERE statement Cypher partial query.
+
+        Args:
+            item: A string representing variable or property. operator: A string
+            representing the operator. literal: A value that will be converted
+            to Cypher value, such as int, float, string, etc. expression: A node
+            label or property that won't be converted to Cypher value (no
+            additional quotes will be added).
+        Raises: GQLAlchemyLiteralAndExpressionMissingInWhere: Raises an error
+        when neither literal nor expression keyword arguments were provided.
+        GQLAlchemyExtraKeywordArgumentsInWhere: Raises an error when both
+        literal and expression keyword arguments were provided.
+        """
         # WHERE item operator (literal | expression)
         # item: variable | property
         # expression: label | property
@@ -480,22 +519,7 @@ class DeclarativeBase(ABC):
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        if literal is None:
-            if expression is None:
-                raise GQLAlchemyLiteralAndExpressionMissingInWhere
-            self._query.append(
-                WhereConditionPartialQuery(WhereConditionConstants.WHERE, separator.join([item, operator, expression]))
-            )
-            return self
-        if expression is not None:
-            raise GQLAlchemyExtraKeywordArgumentsInWhere
-
-        self._query.append(
-            WhereConditionPartialQuery(
-                WhereConditionConstants.WHERE, separator.join([item, operator, to_cypher_value(literal)])
-            )
-        )
-        return self
+        return self.create_where_query(WhereConditionConstants.WHERE, item, operator, separator, literal, expression)
 
     def and_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates an AND (expression) statement Cypher partial query."""
@@ -504,22 +528,7 @@ class DeclarativeBase(ABC):
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        if literal is None:
-            if expression is None:
-                raise GQLAlchemyLiteralAndExpressionMissingInWhere
-            self._query.append(
-                WhereConditionPartialQuery(WhereConditionConstants.AND, separator.join([item, operator, expression]))
-            )
-            return self
-        if expression is not None:
-            raise GQLAlchemyExtraKeywordArgumentsInWhere
-
-        self._query.append(
-            WhereConditionPartialQuery(
-                WhereConditionConstants.AND, separator.join([item, operator, to_cypher_value(literal)])
-            )
-        )
-        return self
+        return self.create_where_query(WhereConditionConstants.AND, item, operator, separator, literal, expression)
 
     def or_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates an OR (expression) statement Cypher partial query."""
@@ -528,22 +537,7 @@ class DeclarativeBase(ABC):
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        if literal is None:
-            if expression is None:
-                raise GQLAlchemyLiteralAndExpressionMissingInWhere
-            self._query.append(
-                WhereConditionPartialQuery(WhereConditionConstants.OR, separator.join([item, operator, expression]))
-            )
-            return self
-        if expression is not None:
-            raise GQLAlchemyExtraKeywordArgumentsInWhere
-
-        self._query.append(
-            WhereConditionPartialQuery(
-                WhereConditionConstants.OR, separator.join([item, operator, to_cypher_value(literal)])
-            )
-        )
-        return self
+        return self.create_where_query(WhereConditionConstants.OR, item, operator, separator, literal, expression)
 
     def xor_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates a XOR (expression) statement Cypher partial query."""
@@ -552,22 +546,7 @@ class DeclarativeBase(ABC):
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        if literal is None:
-            if expression is None:
-                raise GQLAlchemyLiteralAndExpressionMissingInWhere
-            self._query.append(
-                WhereConditionPartialQuery(WhereConditionConstants.XOR, separator.join([item, operator, expression]))
-            )
-            return self
-        if expression is not None:
-            raise GQLAlchemyExtraKeywordArgumentsInWhere
-
-        self._query.append(
-            WhereConditionPartialQuery(
-                WhereConditionConstants.XOR, separator.join([item, operator, to_cypher_value(literal)])
-            )
-        )
-        return self
+        return self.create_where_query(WhereConditionConstants.XOR, item, operator, separator, literal, expression)
 
     def unwind(self, list_expression: str, variable: str) -> "DeclarativeBase":
         """Creates a UNWIND statement Cypher partial query."""

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -470,9 +470,24 @@ class DeclarativeBase(ABC):
 
         return self
 
-    def create_where_query(
+    def build_where_query(
         self, statement: str, item: str, operator: str, separator: str, literal: Any, expression: Any
     ):
+        """Builds parts of a WHERE Cypher query divided by the boolean operators.
+
+        Args:
+            item: A string representing variable or property.
+            operator: A string representing the operator.
+            literal: A value that will be converted to Cypher value, such as int, float, string, etc.
+            expression: A node label or property that won't be converted to Cypher value (no additional quotes will be added).
+
+        Raises:
+            GQLAlchemyLiteralAndExpressionMissingInWhere: Raises an error when neither literal nor expression keyword arguments were provided.
+            GQLAlchemyExtraKeywordArgumentsInWhere: Raises an error when both literal and expression keyword arguments were provided.
+
+        Returns:
+            self: A partial Cypher query built from the given parameters.
+        """
 
         if statement == WhereConditionConstants.WHERE:
             clause = WhereConditionConstants.WHERE
@@ -503,12 +518,13 @@ class DeclarativeBase(ABC):
         Args:
             item: A string representing variable or property.
             operator: A string representing the operator.
+
+        Kwargs:
             literal: A value that will be converted to Cypher value, such as int, float, string, etc.
             expression: A node label or property that won't be converted to Cypher value (no additional quotes will be added).
 
-        Raises:
-            GQLAlchemyLiteralAndExpressionMissingInWhere: Raises an error when neither literal nor expression keyword arguments were provided.
-            GQLAlchemyExtraKeywordArgumentsInWhere: Raises an error when both literal and expression keyword arguments were provided.
+        Returns:
+            self: A partial Cypher query built from the given parameters.
         """
         # WHERE item operator (literal | expression)
         # item: variable | property
@@ -518,34 +534,70 @@ class DeclarativeBase(ABC):
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        return self.create_where_query(WhereConditionConstants.WHERE, item, operator, separator, literal, expression)
+        return self.build_where_query(WhereConditionConstants.WHERE, item, operator, separator, literal, expression)
 
     def and_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
-        """Creates an AND (expression) statement Cypher partial query."""
+        """Creates an AND statement as a part of WHERE Cypher partial query.
+
+        Args:
+            item: A string representing variable or property.
+            operator: A string representing the operator.
+
+        Kwargs:
+            literal: A value that will be converted to Cypher value, such as int, float, string, etc.
+            expression: A node label or property that won't be converted to Cypher value (no additional quotes will be added).
+
+        Returns:
+            self: A partial Cypher query built from the given parameters.
+        """
 
         literal = kwargs.get("literal")
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        return self.create_where_query(WhereConditionConstants.AND, item, operator, separator, literal, expression)
+        return self.build_where_query(WhereConditionConstants.AND, item, operator, separator, literal, expression)
 
     def or_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
-        """Creates an OR (expression) statement Cypher partial query."""
+        """Creates an OR statement as a part of WHERE Cypher partial query.
+
+        Args:
+            item: A string representing variable or property.
+            operator: A string representing the operator.
+
+        Kwargs:
+            literal: A value that will be converted to Cypher value, such as int, float, string, etc.
+            expression: A node label or property that won't be converted to Cypher value (no additional quotes will be added).
+
+        Returns:
+            self: A partial Cypher query built from the given parameters.
+        """
 
         literal = kwargs.get("literal")
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        return self.create_where_query(WhereConditionConstants.OR, item, operator, separator, literal, expression)
+        return self.build_where_query(WhereConditionConstants.OR, item, operator, separator, literal, expression)
 
     def xor_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
-        """Creates a XOR (expression) statement Cypher partial query."""
+        """Creates an XOR statement as a part of WHERE Cypher partial query.
+
+        Args:
+            item: A string representing variable or property.
+            operator: A string representing the operator.
+
+        Kwargs:
+            literal: A value that will be converted to Cypher value, such as int, float, string, etc.
+            expression: A node label or property that won't be converted to Cypher value (no additional quotes will be added).
+
+        Returns:
+            self: A partial Cypher query built from the given parameters.
+        """
 
         literal = kwargs.get("literal")
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        return self.create_where_query(WhereConditionConstants.XOR, item, operator, separator, literal, expression)
+        return self.build_where_query(WhereConditionConstants.XOR, item, operator, separator, literal, expression)
 
     def unwind(self, list_expression: str, variable: str) -> "DeclarativeBase":
         """Creates a UNWIND statement Cypher partial query."""

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -470,7 +470,7 @@ class DeclarativeBase(ABC):
 
         return self
 
-    def build_where_query(
+    def _build_where_query(
         self, statement: str, item: str, operator: str, separator: str, literal: Any, expression: Any
     ):
         """Builds parts of a WHERE Cypher query divided by the boolean operators.
@@ -510,6 +510,7 @@ class DeclarativeBase(ABC):
         self._query.append(
             WhereConditionPartialQuery(clause, separator.join([item, operator, to_cypher_value(literal)]))
         )
+
         return self
 
     def where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
@@ -534,7 +535,7 @@ class DeclarativeBase(ABC):
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        return self.build_where_query(WhereConditionConstants.WHERE, item, operator, separator, literal, expression)
+        return self._build_where_query(WhereConditionConstants.WHERE, item, operator, separator, literal, expression)
 
     def and_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates an AND statement as a part of WHERE Cypher partial query.
@@ -555,7 +556,7 @@ class DeclarativeBase(ABC):
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        return self.build_where_query(WhereConditionConstants.AND, item, operator, separator, literal, expression)
+        return self._build_where_query(WhereConditionConstants.AND, item, operator, separator, literal, expression)
 
     def or_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates an OR statement as a part of WHERE Cypher partial query.
@@ -576,7 +577,7 @@ class DeclarativeBase(ABC):
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        return self.build_where_query(WhereConditionConstants.OR, item, operator, separator, literal, expression)
+        return self._build_where_query(WhereConditionConstants.OR, item, operator, separator, literal, expression)
 
     def xor_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Creates an XOR statement as a part of WHERE Cypher partial query.
@@ -597,7 +598,7 @@ class DeclarativeBase(ABC):
         expression = kwargs.get("expression")
         separator = "" if operator == ":" else " "
 
-        return self.build_where_query(WhereConditionConstants.XOR, item, operator, separator, literal, expression)
+        return self._build_where_query(WhereConditionConstants.XOR, item, operator, separator, literal, expression)
 
     def unwind(self, list_expression: str, variable: str) -> "DeclarativeBase":
         """Creates a UNWIND statement Cypher partial query."""

--- a/tests/docs/test_ogm.py
+++ b/tests/docs/test_ogm.py
@@ -64,7 +64,7 @@ class TestMapNodesAndRelationships:
             description="Hi, I am streamer!",
         ).save(db)
 
-        result = next(match().node("Streamer", variable="s").where("s.id", "=", "7").return_().execute())["s"]
+        result = next(match().node("Streamer", variable="s").where("s.id", "=", literal="7").return_().execute())["s"]
 
         assert result.id == streamer.id
         assert result.username == streamer.username
@@ -110,7 +110,7 @@ class TestSaveNodesAndRelationships:
         user = UserSave(id="3", username="John").save(db)
         language = Language(name="en").save(db)
 
-        result = next(match().node("UserSave", variable="u").where("u.id", "=", "3").return_().execute())["u"]
+        result = next(match().node("UserSave", variable="u").where("u.id", "=", literal="3").return_().execute())["u"]
 
         assert result.id == user.id
         assert result.username == user.username
@@ -126,7 +126,7 @@ class TestSaveNodesAndRelationships:
         db.save_node(user)
         db.save_node(language)
 
-        result = next(match().node("UserSave", variable="u").where("u.id", "=", "4").return_().execute())["u"]
+        result = next(match().node("UserSave", variable="u").where("u.id", "=", literal="4").return_().execute())["u"]
 
         assert result.id == user.id
         assert result.username == user.username

--- a/tests/docs/test_ogm.py
+++ b/tests/docs/test_ogm.py
@@ -64,7 +64,9 @@ class TestMapNodesAndRelationships:
             description="Hi, I am streamer!",
         ).save(db)
 
-        result = next(match().node("Streamer", variable="s").where("s.id", "=", literal="7").return_().execute())["s"]
+        result = next(
+            match().node("Streamer", variable="s").where(item="s.id", operator="=", literal="7").return_().execute()
+        )["s"]
 
         assert result.id == streamer.id
         assert result.username == streamer.username
@@ -110,7 +112,9 @@ class TestSaveNodesAndRelationships:
         user = UserSave(id="3", username="John").save(db)
         language = Language(name="en").save(db)
 
-        result = next(match().node("UserSave", variable="u").where("u.id", "=", literal="3").return_().execute())["u"]
+        result = next(
+            match().node("UserSave", variable="u").where(item="u.id", operator="=", literal="3").return_().execute()
+        )["u"]
 
         assert result.id == user.id
         assert result.username == user.username
@@ -126,7 +130,9 @@ class TestSaveNodesAndRelationships:
         db.save_node(user)
         db.save_node(language)
 
-        result = next(match().node("UserSave", variable="u").where("u.id", "=", literal="4").return_().execute())["u"]
+        result = next(
+            match().node("UserSave", variable="u").where(item="u.id", operator="=", literal="4").return_().execute()
+        )["u"]
 
         assert result.id == user.id
         assert result.username == user.username

--- a/tests/docs/test_query_builder.py
+++ b/tests/docs/test_query_builder.py
@@ -117,8 +117,8 @@ def test_filter_data_1(memgraph):
         .node("Person", variable="p1")
         .to("FRIENDS_WITH")
         .node("Person", variable="p2")
-        .where("n.name", "=", "Ron")
-        .or_where("m.id", "=", 0)
+        .where("n.name", "=", literal="Ron")
+        .or_where("m.id", "=", literal=0)
         .return_()
     )
 

--- a/tests/docs/test_query_builder.py
+++ b/tests/docs/test_query_builder.py
@@ -117,8 +117,8 @@ def test_filter_data_1(memgraph):
         .node("Person", variable="p1")
         .to("FRIENDS_WITH")
         .node("Person", variable="p2")
-        .where("n.name", "=", literal="Ron")
-        .or_where("m.id", "=", literal=0)
+        .where(item="n.name", operator="=", literal="Ron")
+        .or_where(item="m.id", operator="=", literal=0)
         .return_()
     )
 

--- a/tests/memgraph/test_query_builder.py
+++ b/tests/memgraph/test_query_builder.py
@@ -349,7 +349,7 @@ def test_where_no_lhs(memgraph):
             .return_()
         )
 
-    assert "DeclarativeBase.where() missing 1 required positional argument:" in str(e_info.value)
+    assert "where() missing 1 required positional argument:" in str(e_info.value)
 
 
 def test_where_no_rhs(memgraph):
@@ -452,7 +452,7 @@ def test_or_where_no_lhs(memgraph):
             .return_()
         )
 
-    assert "DeclarativeBase.or_where() missing 1 required positional argument:" in str(e_info.value)
+    assert "or_where() missing 1 required positional argument:" in str(e_info.value)
 
 
 def test_or_where_no_rhs(memgraph):
@@ -557,7 +557,7 @@ def test_and_where_no_lhs(memgraph):
             .return_()
         )
 
-    assert "DeclarativeBase.and_where() missing 1 required positional argument:" in str(e_info.value)
+    assert "and_where() missing 1 required positional argument:" in str(e_info.value)
 
 
 def test_and_where_no_rhs(memgraph):
@@ -662,7 +662,7 @@ def test_xor_where_no_lhs(memgraph):
             .return_()
         )
 
-    assert "DeclarativeBase.xor_where() missing 1 required positional argument:" in str(e_info.value)
+    assert "xor_where() missing 1 required positional argument:" in str(e_info.value)
 
 
 def test_xor_where_no_rhs(memgraph):

--- a/tests/memgraph/test_query_builder.py
+++ b/tests/memgraph/test_query_builder.py
@@ -286,6 +286,7 @@ def test_load_csv_no_header(memgraph):
         query_builder.execute()
     mock.assert_called_with(expected_query)
 
+
 def test_where_literal(memgraph):
     query_builder = (
         QueryBuilder()
@@ -619,6 +620,7 @@ def test_xor_and_where_extra_values(memgraph):
             .xor_where(item="n.name", operator="=", literal="best_name", expression="Node")
             .return_()
         )
+
 
 def test_get_single(memgraph):
     query_builder = QueryBuilder().match().node("L1", variable="n").to("TO").node("L2", variable="m").return_({"n": ""})


### PR DESCRIPTION
### Description

Changed `where()`, `and_where()`, `or_where()` and `xor_where()` methods (added keyword arguments). Now label can be used as a left-hand side value in where clause.
Added tests for all methods.

### Pull request type

- [x] Bugfix 
- [x] Refactoring with functional or API changes
- [x] Documentation content changes

### Related issues

Closes https://github.com/memgraph/gqlalchemy/issues/74

######################################

### Reviewer checklist (the reviewer checks this part)
- [ ] Core feature implementation
- [ ] Tests
- [ ] Code documentation
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)

######################################
