### PR TITLE
[develop < T0046-GA] Add order by descending

### DIFF
--- a/gqlalchemy/exceptions.py
+++ b/gqlalchemy/exceptions.py
@@ -40,8 +40,8 @@ db = Memgraph()
 SQLitePropertyDatabase("path-to-sqlite-db", db)
 """
 
-MISSING_ORDERING = """
-The second argument of the Tuple must be ordering: ASC, ASCENDING, DESC or DESCENDING.
+MISSING_ORDER = """
+The second argument of the tuple must be order: ASC, ASCENDING, DESC or DESCENDING.
 """
 
 ORDER_BY_TYPE_ERROR = """
@@ -97,10 +97,10 @@ class GQLAlchemyOnDiskPropertyDatabaseNotDefinedError(GQLAlchemyError):
         self.message = ON_DISK_PROPERTY_DATABASE_NOT_DEFINED_ERROR
 
 
-class GQLAlchemyMissingOrdering(GQLAlchemyError):
+class GQLAlchemyMissingOrder(GQLAlchemyError):
     def __init__(self):
         super().__init__()
-        self.message = MISSING_ORDERING
+        self.message = MISSING_ORDER
 
 
 class GQLAlchemyOrderByTypeError(TypeError):

--- a/gqlalchemy/exceptions.py
+++ b/gqlalchemy/exceptions.py
@@ -38,6 +38,10 @@ MISSING_ORDERING = """
 The second argument of the Tuple must be ordering: ASC, ASCENDING, DESC or DESCENDING.
 """
 
+ORDER_BY_TYPE_ERROR = """
+TypeError: The argument provided is of wrong type. Please provide str, tuple[str, str] or list[tuple[str, str]].
+"""
+
 
 class GQLAlchemyWarning(Warning):
     pass
@@ -76,3 +80,9 @@ class GQLAlchemyMissingOrdering(GQLAlchemyError):
     def __init__(self):
         super().__init__()
         self.message = MISSING_ORDERING
+
+
+class GQLAlchemyOrderByTypeError(TypeError):
+    def __init__(self):
+        super().__init__()
+        self.message = ORDER_BY_TYPE_ERROR

--- a/gqlalchemy/exceptions.py
+++ b/gqlalchemy/exceptions.py
@@ -46,6 +46,7 @@ The second argument of the Tuple must be ordering: ASC, ASCENDING, DESC or DESCE
 
 ORDER_BY_TYPE_ERROR = """
 TypeError: The argument provided is of wrong type. Please provide str, tuple[str, str] or list[tuple[str, str]].
+"""
 
 LITERAL_AND_EXPRESSION_MISSING_IN_WHERE = """
 Can't create WHERE query without providing either 'literal' or 'expression' keyword arguments, that can be literals, labels or properties.

--- a/gqlalchemy/exceptions.py
+++ b/gqlalchemy/exceptions.py
@@ -34,6 +34,10 @@ db = Memgraph()
 SQLitePropertyDatabase("path-to-sqlite-db", db)
 """
 
+MISSING_ORDERING = """
+The second argument of the Tuple must be ordering: ASC, ASCENDING, DESC or DESCENDING.
+"""
+
 
 class GQLAlchemyWarning(Warning):
     pass
@@ -66,3 +70,9 @@ class GQLAlchemyOnDiskPropertyDatabaseNotDefinedError(GQLAlchemyError):
     def __init__(self):
         super().__init__()
         self.message = ON_DISK_PROPERTY_DATABASE_NOT_DEFINED_ERROR
+
+
+class GQLAlchemyMissingOrdering(GQLAlchemyError):
+    def __init__(self):
+        super().__init__()
+        self.message = MISSING_ORDERING

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -146,7 +146,7 @@ class CallPartialQuery(PartialQuery):
 
 
 class WhereConditionPartialQuery(PartialQuery):
-    def __init__(self, item: str, operator: str, keyword: str = "", **kwargs):
+    def __init__(self, item: str, operator: str, keyword: str = None, **kwargs):
         super().__init__(type=DeclarativeBaseTypes.WHERE)
 
         self.keyword = keyword
@@ -154,8 +154,8 @@ class WhereConditionPartialQuery(PartialQuery):
 
     def construct_query(self) -> str:
         """Constructs a where partial query."""
-        item = self.keyword if self.keyword != "" else self.type
-        return f" {item} {self.query} "
+
+        return f" {self.keyword if self.keyword is not None else self.type} {self.query} "
 
     def _build_where_query(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
         """Builds parts of a WHERE Cypher query divided by the boolean operators."""

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -550,6 +550,22 @@ class DeclarativeBase(ABC):
 
         Returns:
             self: A partial Cypher query built from the given parameters.
+
+        Examples:
+            Filtering query results by the equality of `name` properties of two connected nodes.
+
+            Python: `match().node(variable="n").to().node(variable="m").where(item="n.name", operator="=", expression="m.name").return_()`
+            Cypher: `MATCH (n)-[]->(m) WHERE n.name = m.name RETURN *;`
+
+            Filtering query results by the node label.
+
+            Python: `match().node(variable="n").where(item="n", operator=":", expression="User").return_()`
+            Cypher: `MATCH (n) WHERE n:User RETURN *;`
+
+            Filtering query results by the comparison of node property and literal.
+
+            Python: `match().node(variable="n").where(item="n.age", operator=">", literal=18).return_()`
+            Cypher: `MATCH (n) WHERE n.age > 18 RETURN *;`
         """
         # WHERE item operator (literal | expression)
         # item: variable | property
@@ -672,6 +688,13 @@ class DeclarativeBase(ABC):
 
         Returns:
             self: A partial Cypher query built from the given parameters.
+
+        Examples:
+            Ordering query results by the property `n.name` in ascending order
+            and by the property `n.last_name` in descending order:
+
+            Python: `match().node(variable="n").return_().order_by(properties=["n.name", ("n.last_name", Order.DESC)])`
+            Cypher: `MATCH (n) RETURN * ORDER BY n.name, n.last_name DESC;`
         """
 
         self._query.append(OrderByPartialQuery(properties=properties))

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -348,7 +348,9 @@ class OrderByPartialQuery(PartialQuery):
     def construct_query(self) -> str:
         """Creates a ORDER BY statement Cypher partial query."""
 
-        return f" {self.type} {(self._read_list(self.properties)) if isinstance(self.properties, list) else self._read_item(self.properties)} "
+        return f""" {self.type} {(self._read_list(self.properties)) 
+                                if isinstance(self.properties, list) 
+                                else self._read_item(self.properties)} """
 
     def _read_item(self, item: Union[str, Tuple[str, Order]]) -> str:
         if isinstance(item, str):

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -599,6 +599,29 @@ class DeclarativeBase(ABC):
         return self
 
     def where_not(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
+        """Creates a WHERE NOT statement Cypher partial query.
+
+        Args:
+            item: A string representing variable or property.
+            operator: A string representing the operator.
+
+        Kwargs:
+            literal: A value that will be converted to Cypher value, such as int, float, string, etc.
+            expression: A node label or property that won't be converted to Cypher value (no additional quotes will be added).
+
+        Raises:
+            GQLAlchemyLiteralAndExpressionMissingInWhere: Raises an error when neither literal nor expression keyword arguments were provided.
+            GQLAlchemyExtraKeywordArgumentsInWhere: Raises an error when both literal and expression keyword arguments were provided.
+
+        Returns:
+            self: A partial Cypher query built from the given parameters.
+
+        Examples:
+            Filtering query results by the equality of `name` properties of two connected nodes.
+
+            Python: `match().node(variable="n").to().node(variable="m").where_not(item="n.name", operator="=", expression="m.name").return_()`
+            Cypher: `MATCH (n)-[]->(m) WHERE NOT n.name = m.name RETURN *;`
+        """
         self._query.append(WhereNotConditionPartialQuery(item=item, operator=operator, **kwargs))
 
         return self
@@ -616,12 +639,38 @@ class DeclarativeBase(ABC):
 
         Returns:
             self: A partial Cypher query built from the given parameters.
+
+        Examples:
+            Filtering query results by node label or the comparison of node property and literal.
+
+            Python: `match().node(variable="n").where(item="n", operator=":", expression="User").and_where(item="n.age", operator=">", literal=18).return_()`
+            Cypher: `MATCH (n) WHERE n:User AND n.age > 18 RETURN *;`
         """
         self._query.append(AndWhereConditionPartialQuery(item=item, operator=operator, **kwargs))
 
         return self
 
     def and_not_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
+        """Creates an AND NOT statement as a part of WHERE Cypher partial query.
+
+        Args:
+            item: A string representing variable or property.
+            operator: A string representing the operator.
+
+        Kwargs:
+            literal: A value that will be converted to Cypher value, such as int, float, string, etc.
+            expression: A node label or property that won't be converted to Cypher value (no additional quotes will be added).
+
+        Returns:
+            self: A partial Cypher query built from the given parameters.
+
+        Examples:
+            Filtering query results by node label or the comparison of node property and literal.
+
+            Python: `match().node(variable="n").where(item="n", operator=":", expression="User").and_not_where(item="n.age", operator=">", literal=18).return_()`
+            Cypher: `MATCH (n) WHERE n:User AND NOT n.age > 18 RETURN *;`
+        """
+
         self._query.append(AndNotWhereConditionPartialQuery(item=item, operator=operator, **kwargs))
 
         return self
@@ -639,6 +688,12 @@ class DeclarativeBase(ABC):
 
         Returns:
             self: A partial Cypher query built from the given parameters.
+
+        Examples:
+            Filtering query results by node label or the comparison of node property and literal.
+
+            Python: `match().node(variable="n").where(item="n", operator=":", expression="User").or_where(item="n.age", operator=">", literal=18).return_()`
+            Cypher: `MATCH (n) WHERE n:User OR n.age > 18 RETURN *;`
         """
 
         self._query.append(OrWhereConditionPartialQuery(item=item, operator=operator, **kwargs))
@@ -646,6 +701,26 @@ class DeclarativeBase(ABC):
         return self
 
     def or_not_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
+        """Creates an OR NOT statement as a part of WHERE Cypher partial query.
+
+        Args:
+            item: A string representing variable or property.
+            operator: A string representing the operator.
+
+        Kwargs:
+            literal: A value that will be converted to Cypher value, such as int, float, string, etc.
+            expression: A node label or property that won't be converted to Cypher value (no additional quotes will be added).
+
+        Returns:
+            self: A partial Cypher query built from the given parameters.
+
+        Examples:
+            Filtering query results by node label or the comparison of node property and literal.
+
+            Python: `match().node(variable="n").where(item="n", operator=":", expression="User").or_not_where(item="n.age", operator=">", literal=18).return_()`
+            Cypher: `MATCH (n) WHERE n:User OR NOT n.age > 18 RETURN *;`
+        """
+
         self._query.append(OrNotWhereConditionPartialQuery(item=item, operator=operator, **kwargs))
 
         return self
@@ -663,6 +738,12 @@ class DeclarativeBase(ABC):
 
         Returns:
             self: A partial Cypher query built from the given parameters.
+
+        Examples:
+            Filtering query results by node label or the comparison of node property and literal.
+
+            Python: `match().node(variable="n").where(item="n", operator=":", expression="User").xor_where(item="n.age", operator=">", literal=18).return_()`
+            Cypher: `MATCH (n) WHERE n:User XOR n.age > 18 RETURN *;`
         """
 
         self._query.append(XorWhereConditionPartialQuery(item=item, operator=operator, **kwargs))
@@ -670,6 +751,26 @@ class DeclarativeBase(ABC):
         return self
 
     def xor_not_where(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
+        """Creates an XOR NOT statement as a part of WHERE Cypher partial query.
+
+        Args:
+            item: A string representing variable or property.
+            operator: A string representing the operator.
+
+        Kwargs:
+            literal: A value that will be converted to Cypher value, such as int, float, string, etc.
+            expression: A node label or property that won't be converted to Cypher value (no additional quotes will be added).
+
+        Returns:
+            self: A partial Cypher query built from the given parameters.
+
+        Examples:
+            Filtering query results by node label or the comparison of node property and literal.
+
+            Python: `match().node(variable="n").where(item="n", operator=":", expression="User").xor_not_where(item="n.age", operator=">", literal=18).return_()`
+            Cypher: `MATCH (n) WHERE n:User XOR NOT n.age > 18 RETURN *;`
+        """
+
         self._query.append(XorNotWhereConditionPartialQuery(item=item, operator=operator, **kwargs))
 
         return self

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -337,15 +337,13 @@ class OrderByPartialQuery(PartialQuery):
         return f" ORDER BY {self.properties} "
 
 
-class OrderByDescPartialQuery(PartialQuery):
+class OrderByDescPartialQuery(OrderByPartialQuery):
     def __init__(self, properties: str):
-        super().__init__(DeclarativeBaseTypes.ORDER_BY_DESC)
-
-        self.properties = properties
+        super().__init__(properties)
 
     def construct_query(self) -> str:
-        """Creates a ORDER BY statement Cypher partial query."""
-        return f"{OrderByPartialQuery(self.properties).construct_query()}DESC "
+        """Creates an ORDER BY DESC statement Cypher partial query."""
+        return super().construct_query() + "DESC "
 
 
 class LimitPartialQuery(PartialQuery):

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 from .memgraph import Connection, Memgraph
 from .utilities import to_cypher_labels, to_cypher_properties, to_cypher_value
 from .models import Node, Relationship
-from .exceptions import GQLAlchemyMissingOrdering
+from .exceptions import GQLAlchemyMissingOrdering, GQLAlchemyOrderByTypeError
 
 
 class DeclarativeBaseTypes:
@@ -351,7 +351,7 @@ class OrderByPartialQuery(PartialQuery):
         elif isinstance(item, tuple):
             return f"{self._read_tuple(item)}"
         else:
-            raise GQLAlchemyMissingOrdering  # @TODO: raise TypeError with adequate message
+            raise GQLAlchemyOrderByTypeError
 
     def _read_list(self, property: List[Union[str, Tuple[str, Order]]]):
         return ", ".join(self._read_item(item=item) for item in property)

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -26,7 +26,6 @@ class DeclarativeBaseTypes:
     CALL = "CALL"
     CREATE = "CREATE"
     DELETE = "DELETE"
-    DESC = "DESC"
     EDGE = "EDGE"
     LIMIT = "LIMIT"
     LOAD_CSV = "LOAD_CSV"
@@ -34,6 +33,7 @@ class DeclarativeBaseTypes:
     MERGE = "MERGE"
     NODE = "NODE"
     ORDER_BY = "ORDER_BY"
+    ORDER_BY_DESC = "ORDER_BY_DESC"
     OR_WHERE = "OR_WHERE"
     REMOVE = "REMOVE"
     RETURN = "RETURN"
@@ -339,13 +339,13 @@ class OrderByPartialQuery(PartialQuery):
 
 class OrderByDescPartialQuery(PartialQuery):
     def __init__(self, properties: str):
-        super().__init__(DeclarativeBaseTypes.DESC)
+        super().__init__(DeclarativeBaseTypes.ORDER_BY_DESC)
 
         self.properties = properties
 
     def construct_query(self) -> str:
         """Creates a ORDER BY statement Cypher partial query."""
-        return OrderByPartialQuery(self.properties).construct_query() + "DESC "
+        return f"{OrderByPartialQuery(self.properties).construct_query()}DESC "
 
 
 class LimitPartialQuery(PartialQuery):

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -26,6 +26,7 @@ class DeclarativeBaseTypes:
     CALL = "CALL"
     CREATE = "CREATE"
     DELETE = "DELETE"
+    DESC = "DESC"
     EDGE = "EDGE"
     LIMIT = "LIMIT"
     LOAD_CSV = "LOAD_CSV"
@@ -336,6 +337,17 @@ class OrderByPartialQuery(PartialQuery):
         return f" ORDER BY {self.properties} "
 
 
+class OrderByDescPartialQuery(PartialQuery):
+    def __init__(self, properties: str):
+        super().__init__(DeclarativeBaseTypes.DESC)
+
+        self.properties = properties
+
+    def construct_query(self) -> str:
+        """Creates a ORDER BY statement Cypher partial query."""
+        return OrderByPartialQuery(self.properties).construct_query() + "DESC "
+
+
 class LimitPartialQuery(PartialQuery):
     def __init__(self, integer_expression: str):
         super().__init__(DeclarativeBaseTypes.LIMIT)
@@ -576,6 +588,12 @@ class DeclarativeBase(ABC):
     def order_by(self, properties: str) -> "DeclarativeBase":
         """Creates a ORDER BY statement Cypher partial query."""
         self._query.append(OrderByPartialQuery(properties))
+
+        return self
+
+    def order_by_desc(self, properties: str) -> "DeclarativeBase":
+        """Creates an ORDER BY DESC statement Cypher partial query."""
+        self._query.append(OrderByDescPartialQuery(properties))
 
         return self
 

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -348,8 +348,8 @@ class OrderByPartialQuery(PartialQuery):
     def construct_query(self) -> str:
         """Creates a ORDER BY statement Cypher partial query."""
 
-        return f""" {self.type} {(self._read_list(self.properties)) 
-                                if isinstance(self.properties, list) 
+        return f""" {self.type} {(self._read_list(self.properties))
+                                if isinstance(self.properties, list)
                                 else self._read_item(self.properties)} """
 
     def _read_item(self, item: Union[str, Tuple[str, Order]]) -> str:

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -157,7 +157,6 @@ class WhereConditionPartialQuery(PartialQuery):
 
     def construct_query(self) -> str:
         """Constructs a where partial query."""
-
         return f" {self.type} {self.query} "
 
     def _build_where_query(self, item: str, operator: str, **kwargs) -> "DeclarativeBase":
@@ -402,7 +401,6 @@ class OrderByPartialQuery(PartialQuery):
 
     def construct_query(self) -> str:
         """Creates a ORDER BY statement Cypher partial query."""
-
         return f" {self.type} {self.query} "
 
     def _order_by_read_item(self, item: Union[str, Tuple[str, Order]]) -> str:
@@ -593,7 +591,6 @@ class DeclarativeBase(ABC):
         # WHERE item operator (literal | expression)
         # item: variable | property
         # expression: label | property
-
         self._query.append(WhereConditionPartialQuery(item=item, operator=operator, **kwargs))
 
         return self
@@ -670,7 +667,6 @@ class DeclarativeBase(ABC):
             Python: `match().node(variable="n").where(item="n", operator=":", expression="User").and_not_where(item="n.age", operator=">", literal=18).return_()`
             Cypher: `MATCH (n) WHERE n:User AND NOT n.age > 18 RETURN *;`
         """
-
         self._query.append(AndNotWhereConditionPartialQuery(item=item, operator=operator, **kwargs))
 
         return self
@@ -695,7 +691,6 @@ class DeclarativeBase(ABC):
             Python: `match().node(variable="n").where(item="n", operator=":", expression="User").or_where(item="n.age", operator=">", literal=18).return_()`
             Cypher: `MATCH (n) WHERE n:User OR n.age > 18 RETURN *;`
         """
-
         self._query.append(OrWhereConditionPartialQuery(item=item, operator=operator, **kwargs))
 
         return self
@@ -720,7 +715,6 @@ class DeclarativeBase(ABC):
             Python: `match().node(variable="n").where(item="n", operator=":", expression="User").or_not_where(item="n.age", operator=">", literal=18).return_()`
             Cypher: `MATCH (n) WHERE n:User OR NOT n.age > 18 RETURN *;`
         """
-
         self._query.append(OrNotWhereConditionPartialQuery(item=item, operator=operator, **kwargs))
 
         return self
@@ -745,7 +739,6 @@ class DeclarativeBase(ABC):
             Python: `match().node(variable="n").where(item="n", operator=":", expression="User").xor_where(item="n.age", operator=">", literal=18).return_()`
             Cypher: `MATCH (n) WHERE n:User XOR n.age > 18 RETURN *;`
         """
-
         self._query.append(XorWhereConditionPartialQuery(item=item, operator=operator, **kwargs))
 
         return self
@@ -770,7 +763,6 @@ class DeclarativeBase(ABC):
             Python: `match().node(variable="n").where(item="n", operator=":", expression="User").xor_not_where(item="n.age", operator=">", literal=18).return_()`
             Cypher: `MATCH (n) WHERE n:User XOR NOT n.age > 18 RETURN *;`
         """
-
         self._query.append(XorNotWhereConditionPartialQuery(item=item, operator=operator, **kwargs))
 
         return self
@@ -840,7 +832,6 @@ class DeclarativeBase(ABC):
             Python: `match().node(variable="n").return_().order_by(properties=["n.name", ("n.last_name", Order.DESC)])`
             Cypher: `MATCH (n) RETURN * ORDER BY n.name, n.last_name DESC;`
         """
-
         self._query.append(OrderByPartialQuery(properties=properties))
 
         return self

--- a/tests/memgraph/test_query_builder.py
+++ b/tests/memgraph/test_query_builder.py
@@ -311,9 +311,9 @@ def test_where_property(memgraph):
     query_builder = (
         QueryBuilder()
         .match()
-        .node("L1", variable="n")
-        .to("TO")
-        .node("L2", variable="m")
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
         .where(item="n.name", operator="=", expression="m.name")
         .return_()
     )
@@ -325,17 +325,53 @@ def test_where_property(memgraph):
     mock.assert_called_with(expected_query)
 
 
+def test_where_not_property(memgraph):
+    query_builder = (
+        QueryBuilder()
+        .match()
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
+        .where_not(item="n.name", operator="=", expression="m.name")
+        .return_()
+    )
+    expected_query = " MATCH (n:L1)-[:TO]->(m:L2) WHERE NOT n.name = m.name RETURN * "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
 def test_where_label(memgraph):
     query_builder = (
         QueryBuilder()
         .match()
-        .node("L1", variable="n")
-        .to("TO")
-        .node("L2", variable="m")
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
         .where(item="n", operator=":", expression="Node")
         .return_()
     )
     expected_query = " MATCH (n:L1)-[:TO]->(m:L2) WHERE n:Node RETURN * "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
+def test_where_not_label(memgraph):
+    query_builder = (
+        QueryBuilder()
+        .match()
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
+        .where_not(item="n", operator=":", expression="Node")
+        .return_()
+    )
+    expected_query = " MATCH (n:L1)-[:TO]->(m:L2) WHERE NOT n:Node RETURN * "
 
     with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
         query_builder.execute()
@@ -348,10 +384,23 @@ def test_where_literal_and_expression_missing(memgraph):
         (
             QueryBuilder()
             .match()
-            .node("L1", variable="n")
-            .to("TO")
-            .node("L2", variable="m")
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
             .where(item="n.name", operator="=")
+            .return_()
+        )
+
+
+def test_where_not_literal_and_expression_missing(memgraph):
+    with pytest.raises(GQLAlchemyLiteralAndExpressionMissingInWhere):
+        (
+            QueryBuilder()
+            .match()
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
+            .where_not(item="n.name", operator="=")
             .return_()
         )
 
@@ -361,10 +410,23 @@ def test_where_extra_values(memgraph):
         (
             QueryBuilder()
             .match()
-            .node("L1", variable="n")
-            .to("TO")
-            .node("L2", variable="m")
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
             .where(item="n.name", operator="=", literal="best_name", expression="Node")
+            .return_()
+        )
+
+
+def test_where_not_extra_values(memgraph):
+    with pytest.raises(GQLAlchemyExtraKeywordArgumentsInWhere):
+        (
+            QueryBuilder()
+            .match()
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
+            .where_not(item="n.name", operator="=", literal="best_name", expression="Node")
             .return_()
         )
 
@@ -373,9 +435,9 @@ def test_or_where_literal(memgraph):
     query_builder = (
         QueryBuilder()
         .match()
-        .node("L1", variable="n")
-        .to("TO")
-        .node("L2", variable="m")
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
         .where(item="n.name", operator="=", literal="best_name")
         .or_where(item="m.id", operator="<", literal=4)
         .return_()
@@ -388,13 +450,32 @@ def test_or_where_literal(memgraph):
     mock.assert_called_with(expected_query)
 
 
+def test_or_not_where_literal(memgraph):
+    query_builder = (
+        QueryBuilder()
+        .match()
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
+        .where(item="n.name", operator="=", literal="best_name")
+        .or_not_where(item="m.id", operator="<", literal=4)
+        .return_()
+    )
+    expected_query = " MATCH (n:L1)-[:TO]->(m:L2) WHERE n.name = 'best_name' OR NOT m.id < 4 RETURN * "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
 def test_or_where_property(memgraph):
     query_builder = (
         QueryBuilder()
         .match()
-        .node("L1", variable="n")
-        .to("TO")
-        .node("L2", variable="m")
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
         .where(item="n.name", operator="=", expression="m.name")
         .or_where(item="m.name", operator="=", expression="n.last_name")
         .return_()
@@ -407,13 +488,32 @@ def test_or_where_property(memgraph):
     mock.assert_called_with(expected_query)
 
 
+def test_or_not_where_property(memgraph):
+    query_builder = (
+        QueryBuilder()
+        .match()
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
+        .where(item="n.name", operator="=", expression="m.name")
+        .or_not_where(item="m.name", operator="=", expression="n.last_name")
+        .return_()
+    )
+    expected_query = " MATCH (n:L1)-[:TO]->(m:L2) WHERE n.name = m.name OR NOT m.name = n.last_name RETURN * "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
 def test_or_where_label(memgraph):
     query_builder = (
         QueryBuilder()
         .match()
-        .node("L1", variable="n")
-        .to("TO")
-        .node("L2", variable="m")
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
         .where(item="n", operator=":", expression="Node")
         .or_where(item="m", operator=":", expression="User")
         .return_()
@@ -426,16 +526,49 @@ def test_or_where_label(memgraph):
     mock.assert_called_with(expected_query)
 
 
+def test_or_not_where_label(memgraph):
+    query_builder = (
+        QueryBuilder()
+        .match()
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
+        .where(item="n", operator=":", expression="Node")
+        .or_not_where(item="m", operator=":", expression="User")
+        .return_()
+    )
+    expected_query = " MATCH (n:L1)-[:TO]->(m:L2) WHERE n:Node OR NOT m:User RETURN * "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
 def test_or_where_literal_and_expression_missing(memgraph):
     with pytest.raises(GQLAlchemyLiteralAndExpressionMissingInWhere):
         (
             QueryBuilder()
             .match()
-            .node("L1", variable="n")
-            .to("TO")
-            .node("L2", variable="m")
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
             .where(item="n.name", operator="=", literal="my_name")
             .or_where(item="m.name", operator="=")
+            .return_()
+        )
+
+
+def test_or_not_where_literal_and_expression_missing(memgraph):
+    with pytest.raises(GQLAlchemyLiteralAndExpressionMissingInWhere):
+        (
+            QueryBuilder()
+            .match()
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
+            .where(item="n.name", operator="=", literal="my_name")
+            .or_not_where(item="m.name", operator="=")
             .return_()
         )
 
@@ -445,11 +578,25 @@ def test_or_where_extra_values(memgraph):
         (
             QueryBuilder()
             .match()
-            .node("L1", variable="n")
-            .to("TO")
-            .node("L2", variable="m")
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
             .where(item="m.name", operator="=", literal="best_name")
             .or_where(item="n.name", operator="=", literal="best_name", expression="Node")
+            .return_()
+        )
+
+
+def test_or_not_where_extra_values(memgraph):
+    with pytest.raises(GQLAlchemyExtraKeywordArgumentsInWhere):
+        (
+            QueryBuilder()
+            .match()
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
+            .where(item="m.name", operator="=", literal="best_name")
+            .or_not_where(item="n.name", operator="=", literal="best_name", expression="Node")
             .return_()
         )
 
@@ -458,9 +605,9 @@ def test_and_where_literal(memgraph):
     query_builder = (
         QueryBuilder()
         .match()
-        .node("L1", variable="n")
-        .to("TO")
-        .node("L2", variable="m")
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
         .where(item="n.name", operator="=", literal="best_name")
         .and_where(item="m.id", operator="<", literal=4)
         .return_()
@@ -473,13 +620,32 @@ def test_and_where_literal(memgraph):
     mock.assert_called_with(expected_query)
 
 
+def test_and_not_where_literal(memgraph):
+    query_builder = (
+        QueryBuilder()
+        .match()
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
+        .where(item="n.name", operator="=", literal="best_name")
+        .and_not_where(item="m.id", operator="<", literal=4)
+        .return_()
+    )
+    expected_query = " MATCH (n:L1)-[:TO]->(m:L2) WHERE n.name = 'best_name' AND NOT m.id < 4 RETURN * "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
 def test_and_where_property(memgraph):
     query_builder = (
         QueryBuilder()
         .match()
-        .node("L1", variable="n")
-        .to("TO")
-        .node("L2", variable="m")
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
         .where(item="n.name", operator="=", expression="m.name")
         .and_where(item="m.name", operator="=", expression="n.last_name")
         .return_()
@@ -492,13 +658,32 @@ def test_and_where_property(memgraph):
     mock.assert_called_with(expected_query)
 
 
-def test_and_or_where_label(memgraph):
+def test_and_not_where_property(memgraph):
     query_builder = (
         QueryBuilder()
         .match()
-        .node("L1", variable="n")
-        .to("TO")
-        .node("L2", variable="m")
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
+        .where(item="n.name", operator="=", expression="m.name")
+        .and_not_where(item="m.name", operator="=", expression="n.last_name")
+        .return_()
+    )
+    expected_query = " MATCH (n:L1)-[:TO]->(m:L2) WHERE n.name = m.name AND NOT m.name = n.last_name RETURN * "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
+def test_and_where_label(memgraph):
+    query_builder = (
+        QueryBuilder()
+        .match()
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
         .where(item="n", operator=":", expression="Node")
         .and_where(item="m", operator=":", expression="User")
         .return_()
@@ -511,16 +696,49 @@ def test_and_or_where_label(memgraph):
     mock.assert_called_with(expected_query)
 
 
+def test_and_not_where_label(memgraph):
+    query_builder = (
+        QueryBuilder()
+        .match()
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node("L2", variable="m")
+        .where(item="n", operator=":", expression="Node")
+        .and_not_where(item="m", operator=":", expression="User")
+        .return_()
+    )
+    expected_query = " MATCH (n:L1)-[:TO]->(m:L2) WHERE n:Node AND NOT m:User RETURN * "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
 def test_and_where_literal_and_expression_missing(memgraph):
     with pytest.raises(GQLAlchemyLiteralAndExpressionMissingInWhere):
         (
             QueryBuilder()
             .match()
-            .node("L1", variable="n")
-            .to("TO")
-            .node("L2", variable="m")
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
             .where(item="n.name", operator="=", literal="my_name")
             .and_where(item="m.name", operator="=")
+            .return_()
+        )
+
+
+def test_and_not_where_literal_and_expression_missing(memgraph):
+    with pytest.raises(GQLAlchemyLiteralAndExpressionMissingInWhere):
+        (
+            QueryBuilder()
+            .match()
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
+            .where(item="n.name", operator="=", literal="my_name")
+            .and_not_where(item="m.name", operator="=")
             .return_()
         )
 
@@ -530,11 +748,25 @@ def test_and_where_extra_values(memgraph):
         (
             QueryBuilder()
             .match()
-            .node("L1", variable="n")
-            .to("TO")
-            .node("L2", variable="m")
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
             .where(item="m.name", operator="=", literal="best_name")
             .and_where(item="n.name", operator="=", literal="best_name", expression="Node")
+            .return_()
+        )
+
+
+def test_and_not_where_extra_values(memgraph):
+    with pytest.raises(GQLAlchemyExtraKeywordArgumentsInWhere):
+        (
+            QueryBuilder()
+            .match()
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
+            .where(item="m.name", operator="=", literal="best_name")
+            .and_not_where(item="n.name", operator="=", literal="best_name", expression="Node")
             .return_()
         )
 
@@ -543,9 +775,9 @@ def test_xor_where_literal(memgraph):
     query_builder = (
         QueryBuilder()
         .match()
-        .node("L1", variable="n")
-        .to("TO")
-        .node("L2", variable="m")
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
         .where(item="n.name", operator="=", literal="best_name")
         .xor_where(item="m.id", operator="<", literal=4)
         .return_()
@@ -558,13 +790,32 @@ def test_xor_where_literal(memgraph):
     mock.assert_called_with(expected_query)
 
 
+def test_xor_not_where_literal(memgraph):
+    query_builder = (
+        QueryBuilder()
+        .match()
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
+        .where(item="n.name", operator="=", literal="best_name")
+        .xor_not_where(item="m.id", operator="<", literal=4)
+        .return_()
+    )
+    expected_query = " MATCH (n:L1)-[:TO]->(m:L2) WHERE n.name = 'best_name' XOR NOT m.id < 4 RETURN * "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
 def test_xor_where_property(memgraph):
     query_builder = (
         QueryBuilder()
         .match()
-        .node("L1", variable="n")
-        .to("TO")
-        .node("L2", variable="m")
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
         .where(item="n.name", operator="=", expression="m.name")
         .xor_where(item="m.name", operator="=", expression="n.last_name")
         .return_()
@@ -577,13 +828,32 @@ def test_xor_where_property(memgraph):
     mock.assert_called_with(expected_query)
 
 
-def test_xor_or_where_label(memgraph):
+def test_xor_not_where_property(memgraph):
     query_builder = (
         QueryBuilder()
         .match()
-        .node("L1", variable="n")
-        .to("TO")
-        .node("L2", variable="m")
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
+        .where(item="n.name", operator="=", expression="m.name")
+        .xor_not_where(item="m.name", operator="=", expression="n.last_name")
+        .return_()
+    )
+    expected_query = " MATCH (n:L1)-[:TO]->(m:L2) WHERE n.name = m.name XOR NOT m.name = n.last_name RETURN * "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
+def test_xor_where_label(memgraph):
+    query_builder = (
+        QueryBuilder()
+        .match()
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
         .where(item="n", operator=":", expression="Node")
         .xor_where(item="m", operator=":", expression="User")
         .return_()
@@ -596,16 +866,49 @@ def test_xor_or_where_label(memgraph):
     mock.assert_called_with(expected_query)
 
 
+def test_xor_not_where_label(memgraph):
+    query_builder = (
+        QueryBuilder()
+        .match()
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
+        .where(item="n", operator=":", expression="Node")
+        .xor_not_where(item="m", operator=":", expression="User")
+        .return_()
+    )
+    expected_query = " MATCH (n:L1)-[:TO]->(m:L2) WHERE n:Node XOR NOT m:User RETURN * "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
 def test_xor_where_literal_and_expression_missing(memgraph):
     with pytest.raises(GQLAlchemyLiteralAndExpressionMissingInWhere):
         (
             QueryBuilder()
             .match()
-            .node("L1", variable="n")
-            .to("TO")
-            .node("L2", variable="m")
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
             .where(item="n.name", operator="=", literal="my_name")
             .xor_where(item="m.name", operator="=")
+            .return_()
+        )
+
+
+def test_xor_not_where_literal_and_expression_missing(memgraph):
+    with pytest.raises(GQLAlchemyLiteralAndExpressionMissingInWhere):
+        (
+            QueryBuilder()
+            .match()
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
+            .where(item="n.name", operator="=", literal="my_name")
+            .xor_not_where(item="m.name", operator="=")
             .return_()
         )
 
@@ -615,13 +918,51 @@ def test_xor_and_where_extra_values(memgraph):
         (
             QueryBuilder()
             .match()
-            .node("L1", variable="n")
-            .to("TO")
-            .node("L2", variable="m")
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
             .where(item="m.name", operator="=", literal="best_name")
             .xor_where(item="n.name", operator="=", literal="best_name", expression="Node")
             .return_()
         )
+
+
+def test_xor_not_and_where_extra_values(memgraph):
+    with pytest.raises(GQLAlchemyExtraKeywordArgumentsInWhere):
+        (
+            QueryBuilder()
+            .match()
+            .node(labels="L1", variable="n")
+            .to(edge_label="TO")
+            .node(labels="L2", variable="m")
+            .where(item="m.name", operator="=", literal="best_name")
+            .xor_not_where(item="n.name", operator="=", literal="best_name", expression="Node")
+            .return_()
+        )
+
+
+def test_and_or_xor_not_where(memgraph):
+    query_builder = (
+        QueryBuilder()
+        .match()
+        .node(labels="L1", variable="n")
+        .to(edge_label="TO")
+        .node(labels="L2", variable="m")
+        .where(item="n", operator=":", expression="Node")
+        .and_where(item="n.age", operator=">", literal=5)
+        .or_where(item="n", operator=":", expression="Node2")
+        .xor_where(item="n.name", operator="=", expression="m.name")
+        .xor_not_where(item="m", operator=":", expression="User")
+        .or_not_where(item="m", operator=":", expression="Node")
+        .and_not_where(item="m.name", operator="=", literal="John")
+        .return_()
+    )
+    expected_query = " MATCH (n:L1)-[:TO]->(m:L2) WHERE n:Node AND n.age > 5 OR n:Node2 XOR n.name = m.name XOR NOT m:User OR NOT m:Node AND NOT m.name = 'John' RETURN * "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
 
 
 def test_get_single(memgraph):

--- a/tests/memgraph/test_query_builder.py
+++ b/tests/memgraph/test_query_builder.py
@@ -428,6 +428,16 @@ def test_orderby_desc(memgraph):
     mock.assert_called_with(expected_query)
 
 
+def test_order_by_desc(memgraph):
+    query_builder = QueryBuilder().match().node(variable="n").return_().order_by_desc("n.id")
+    expected_query = " MATCH (n) RETURN * ORDER BY n.id DESC "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
 def test_limit(memgraph):
     query_builder = QueryBuilder().match().node(variable="n").return_().limit("3")
     expected_query = " MATCH (n) RETURN * LIMIT 3 "

--- a/tests/memgraph/test_query_builder.py
+++ b/tests/memgraph/test_query_builder.py
@@ -32,7 +32,7 @@ from gqlalchemy import (
 from gqlalchemy.memgraph import Memgraph
 from typing import Optional
 from unittest.mock import patch
-from gqlalchemy.exceptions import GQLAlchemyMissingOrdering, GQLAlchemyOrderByTypeError
+from gqlalchemy.exceptions import GQLAlchemyMissingOrder, GQLAlchemyOrderByTypeError
 from gqlalchemy.query_builder import Order
 
 
@@ -780,13 +780,13 @@ def test_order_by_asc(memgraph):
 
 
 def test_order_by_wrong_ordering(memgraph):
-    with pytest.raises(GQLAlchemyMissingOrdering):
-        QueryBuilder().match().node(variable="n").return_().order_by(properties=("n.id", "DESCE")).execute()
+    with pytest.raises(GQLAlchemyMissingOrder):
+        QueryBuilder().match().node(variable="n").return_().order_by(properties=("n.id", "DESCE"))
 
 
 def test_order_by_wrong_type(memgraph):
     with pytest.raises(GQLAlchemyOrderByTypeError):
-        QueryBuilder().match().node(variable="n").return_().order_by(properties=1).execute()
+        QueryBuilder().match().node(variable="n").return_().order_by(properties=1)
 
 
 def test_order_by_properties(memgraph):

--- a/tests/memgraph/test_query_builder.py
+++ b/tests/memgraph/test_query_builder.py
@@ -429,7 +429,7 @@ def test_orderby_desc(memgraph):
 
 
 def test_order_by_desc(memgraph):
-    query_builder = QueryBuilder().match().node(variable="n").return_().order_by_desc("n.id")
+    query_builder = QueryBuilder().match().node(variable="n").return_().order_by_desc(properties="n.id")
     expected_query = " MATCH (n) RETURN * ORDER BY n.id DESC "
 
     with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:

--- a/tests/memgraph/test_query_builder.py
+++ b/tests/memgraph/test_query_builder.py
@@ -29,6 +29,7 @@ from gqlalchemy.memgraph import Memgraph
 from typing import Optional
 from unittest.mock import patch
 from gqlalchemy.exceptions import GQLAlchemyMissingOrdering
+from gqlalchemy.query_builder import Order
 
 
 def test_invalid_match_chain_throws_exception():
@@ -420,7 +421,7 @@ def test_order_by(memgraph):
 
 
 def test_order_by_desc(memgraph):
-    query_builder = QueryBuilder().match().node(variable="n").return_().order_by(("n.id", "DESC"))
+    query_builder = QueryBuilder().match().node(variable="n").return_().order_by(("n.id", Order.DESC))
     expected_query = " MATCH (n) RETURN * ORDER BY n.id DESC "
 
     with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
@@ -430,7 +431,7 @@ def test_order_by_desc(memgraph):
 
 
 def test_order_by_asc(memgraph):
-    query_builder = QueryBuilder().match().node(variable="n").return_().order_by(("n.id", "ASC"))
+    query_builder = QueryBuilder().match().node(variable="n").return_().order_by(("n.id", Order.ASC))
     expected_query = " MATCH (n) RETURN * ORDER BY n.id ASC "
 
     with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
@@ -439,7 +440,7 @@ def test_order_by_asc(memgraph):
     mock.assert_called_with(expected_query)
 
 
-def test_order_by_wrong_ordering(memgraph):
+def test_order_by_wrong_parameter(memgraph):
     with pytest.raises(GQLAlchemyMissingOrdering):
         QueryBuilder().match().node(variable="n").return_().order_by(("n.id", "DESCE")).execute()
 
@@ -450,7 +451,7 @@ def test_order_by_properties(memgraph):
         .match()
         .node(variable="n")
         .return_()
-        .order_by([("n.id", "DESC"), "n.name", ("n.last_name", "DESC")])
+        .order_by([("n.id", Order.DESC), "n.name", ("n.last_name", Order.DESC)])
     )
     expected_query = " MATCH (n) RETURN * ORDER BY n.id DESC, n.name, n.last_name DESC "
 
@@ -468,11 +469,11 @@ def test_order_by_asc_desc(memgraph):
         .return_()
         .order_by(
             [
-                ("n.id", "ASC"),
+                ("n.id", Order.ASC),
                 "n.name",
-                ("n.last_name", "DESC"),
-                ("n.age", "ASCENDING"),
-                ("n.middle_name", "DESCENDING"),
+                ("n.last_name", Order.DESC),
+                ("n.age", Order.ASCENDING),
+                ("n.middle_name", Order.DESCENDING),
             ]
         )
     )


### PR DESCRIPTION
### Description

What's new:
- Exceptions for ordering.
- Enums for Where (WHERE, AND, OR, XOR, NOT) and Order (ASC, ASCENDING, DESC, DESCENDING).
- All where methods (where, and, or, xor) use their classes to construct queries. Those classes inherit from the `WhereConditionPartialQuery` class. 
- All where_not methods (where_not, and_not, or_not, xor_not) use their classes to construct queries. Those classes inherit from the `WhereNotConditionPartialQuery` class, which inherits from the `WhereConditionPartialQuery` class.
- There is one order_by method that allows either property (default ascending order), a tuple of property and order, or a list of either property or tuple of property and order.

### Pull request type

- [x] Feature

######################################

### Reviewer checklist (the reviewer checks this part)
- [ ] Core feature implementation
- [ ] Tests
- [ ] Code documentation
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)

######################################
