### PR TITLE
[develop < T0043-GA] Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,8 @@ Please briefly explain the changes you made here.
 
 ### Pull request type
 
+Please delete options that are not relevant.
+
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, renaming)
@@ -15,7 +17,18 @@ Please briefly explain the changes you made here.
 
 ### Related issues
 
-Delete section if this PR doesn't resolve any issues. Link the issue if it does.
+Delete section if this PR doesn't resolve any issues. 
+
+Closes (link to issue)
+
+### Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
 
 ######################################
 


### PR DESCRIPTION
I updated our PR template with sentence to delete unchecked PR types and added the 'closes' keyword to linked issues that should automatically close the related issue. I also added a checklist that made sense to me but feel free to suggest changes.

