### PR TITLE
[develop < T0070-GA] Add more clauses for base classes

### DIFF
--- a/gqlalchemy/__init__.py
+++ b/gqlalchemy/__init__.py
@@ -29,7 +29,8 @@ from .query_builder import (  # noqa F401
     Call,
     Create,
     InvalidMatchChainException,
-    LoadCSV,
+    Return,
+    LoadCsv,
     Match,
     Merge,
     NoVariablesMatchedException,
@@ -58,4 +59,5 @@ match = Match
 merge = Merge
 unwind = Unwind
 with_ = With
-load_csv = LoadCSV
+return_ = Return
+load_csv = LoadCsv

--- a/gqlalchemy/__init__.py
+++ b/gqlalchemy/__init__.py
@@ -29,6 +29,7 @@ from .query_builder import (  # noqa F401
     Call,
     Create,
     InvalidMatchChainException,
+    LoadCSV,
     Match,
     Merge,
     NoVariablesMatchedException,
@@ -57,3 +58,4 @@ match = Match
 merge = Merge
 unwind = Unwind
 with_ = With
+load_csv = LoadCSV

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -1129,7 +1129,9 @@ class LoadCsv(DeclarativeBase):
 
 
 class Return(DeclarativeBase):
-    def __init__(self, results: Optional[Dict[str, str]] = {}, connection: Optional[Union[Connection, Memgraph]] = None):
+    def __init__(
+        self, results: Optional[Dict[str, str]] = {}, connection: Optional[Union[Connection, Memgraph]] = None
+    ):
         super().__init__(connection)
         self._query.append(ReturnPartialQuery(results))
         self._fetch_results = True

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -1120,3 +1120,9 @@ class With(DeclarativeBase):
     ):
         super().__init__(connection)
         self._query.append(WithPartialQuery(results))
+
+
+class LoadCSV(DeclarativeBase):
+    def __init__(self, path: str, header: bool, row: str, connection: Optional[Union[Connection, Memgraph]] = None):
+        super().__init__(connection)
+        self._query.append(LoadCsvPartialQuery(path, header, row))

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -1122,7 +1122,14 @@ class With(DeclarativeBase):
         self._query.append(WithPartialQuery(results))
 
 
-class LoadCSV(DeclarativeBase):
+class LoadCsv(DeclarativeBase):
     def __init__(self, path: str, header: bool, row: str, connection: Optional[Union[Connection, Memgraph]] = None):
         super().__init__(connection)
         self._query.append(LoadCsvPartialQuery(path, header, row))
+
+
+class Return(DeclarativeBase):
+    def __init__(self, results: Optional[Dict[str, str]] = {}, connection: Optional[Union[Connection, Memgraph]] = None):
+        super().__init__(connection)
+        self._query.append(ReturnPartialQuery(results))
+        self._fetch_results = True

--- a/tests/memgraph/test_query_builder.py
+++ b/tests/memgraph/test_query_builder.py
@@ -27,6 +27,7 @@ from gqlalchemy import (
     unwind,
     with_,
     merge,
+    return_,
     Node,
     Relationship,
     Field,
@@ -1247,6 +1248,16 @@ def test_base_class_with(memgraph):
 def test_base_class_load_csv(memgraph):
     query_builder = load_csv("path/to/my/file.csv", True, "row").return_()
     expected_query = " LOAD CSV FROM 'path/to/my/file.csv' WITH HEADER AS row RETURN * "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
+def test_base_class_return(memgraph):
+    query_builder = return_({"n": "n"})
+    expected_query = " RETURN n "
 
     with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
         query_builder.execute()

--- a/tests/memgraph/test_query_builder.py
+++ b/tests/memgraph/test_query_builder.py
@@ -22,6 +22,8 @@ from gqlalchemy import (
     QueryBuilder,
     match,
     call,
+    create,
+    load_csv,
     unwind,
     with_,
     merge,
@@ -1212,6 +1214,16 @@ def test_base_class_call(memgraph):
     mock.assert_called_with(expected_query)
 
 
+def test_base_class_create(memgraph):
+    query_builder = create().node(variable="n", labels="TEST", prop="test").return_(results={"n": "n"})
+    expected_query = " CREATE (n:TEST {prop: 'test'}) RETURN n "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
 def test_base_class_unwind(memgraph):
     query_builder = unwind("[1, 2, 3]", "x").return_({"x": "x"})
     expected_query = " UNWIND [1, 2, 3] AS x RETURN x "
@@ -1225,6 +1237,16 @@ def test_base_class_unwind(memgraph):
 def test_base_class_with(memgraph):
     query_builder = with_({"10": "n"}).return_({"n": ""})
     expected_query = " WITH 10 AS n RETURN n "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
+def test_base_class_load_csv(memgraph):
+    query_builder = load_csv("path/to/my/file.csv", True, "row").return_()
+    expected_query = " LOAD CSV FROM 'path/to/my/file.csv' WITH HEADER AS row RETURN * "
 
     with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
         query_builder.execute()


### PR DESCRIPTION
### Description

Added load_csv and return to base classes list.
Discuss:
REMOVE, DELETE and SET  are also supported per cypher grammar to be at the start of a query, but I have not included them as in agreement with Ivan they do not make much sense to be used like that, without some variable defined with MATCH in front of them.

Note:
FOREACH will also be in the base classes, but I decided to add it to the FOREACH clause PR, so this PR doesn't have to wait for that one.

### Pull request type

- [x] Bugfix
- [x] Feature

### Related issues

Closes #138 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

######################################

### Reviewer checklist (the reviewer checks this part)
- [ ] Core feature implementation
- [ ] Tests
- [ ] Code documentation
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)

######################################
