### PR TITLE
[develop <  T0089-GA] Create Operator Enum

### DIFF
--- a/gqlalchemy/exceptions.py
+++ b/gqlalchemy/exceptions.py
@@ -73,6 +73,10 @@ TOO_LARGE_TUPLE_IN_RESULT_QUERY = """
 Tuple argument in {clause} clause only has two arguments - variable name and alias.
 """
 
+OPERATOR_TYPE_ERROR = """
+Operator argument in {clause} clause that is a string must be a valid operator.
+"""
+
 
 class QueryClause(Enum):
     WHERE = "WHERE"
@@ -176,6 +180,11 @@ class GQLAlchemyDatabaseError(GQLAlchemyError):
     def __init__(self, message):
         super().__init__()
         self.message = message
+
+
+class GQLAlchemyOperatorTypeError(TypeError):
+    def __init__(self, clause) -> None:
+        self.message = OPERATOR_TYPE_ERROR.format(clause=clause)
 
 
 def gqlalchemy_error_handler(func):

--- a/gqlalchemy/exceptions.py
+++ b/gqlalchemy/exceptions.py
@@ -129,36 +129,14 @@ class GQLAlchemyOrderByTypeError(GQLAlchemyError):
         self.message = ORDER_BY_TYPE_ERROR
 
 
-class GQLAlchemyLiteralAndExpressionMissingInClause(GQLAlchemyError):
+class GQLAlchemyLiteralAndExpressionMissing(GQLAlchemyError):
     def __init__(self, clause: str):
-        super().__init__()
         self.message = LITERAL_AND_EXPRESSION_MISSING.format(clause=clause)
-
-
-class GQLAlchemyLiteralAndExpressionMissingInWhere(GQLAlchemyLiteralAndExpressionMissingInClause):
-    def __init__(self):
-        super().__init__(clause=QueryClause.WHERE)
-
-
-class GQLAlchemyLiteralAndExpressionMissingInSet(GQLAlchemyLiteralAndExpressionMissingInClause):
-    def __init__(self):
-        super().__init__(clause=QueryClause.SET)
 
 
 class GQLAlchemyExtraKeywordArguments(GQLAlchemyError):
     def __init__(self, clause: str):
-        super().__init__()
         self.message = EXTRA_KEYWORD_ARGUMENTS.format(clause=clause)
-
-
-class GQLAlchemyExtraKeywordArgumentsInWhere(GQLAlchemyExtraKeywordArguments):
-    def __init__(self):
-        super().__init__(clause=QueryClause.WHERE)
-
-
-class GQLAlchemyExtraKeywordArgumentsInSet(GQLAlchemyExtraKeywordArguments):
-    def __init__(self):
-        super().__init__(clause=QueryClause.SET)
 
 
 class GQLAlchemyTooLargeTupleInResultQuery(GQLAlchemyError):

--- a/gqlalchemy/loaders.py
+++ b/gqlalchemy/loaders.py
@@ -28,6 +28,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from dataclasses import dataclass, field
 from dacite import from_dict
+from gqlalchemy.query_builder import WhereOperator
 from pyarrow import fs
 from typing import List, Dict, Any, Optional, Union
 import pyarrow.dataset as ds
@@ -382,8 +383,10 @@ class TableToGraphImporter:
     _TriggerQueryTemplate = Template(
         Unwind(list_expression="createdVertices", variable="$node_a")
         .with_(results={"$node_a": ""})
-        .where(item="$node_a:$label_2", operator="MATCH", expression="($node_b:$label_1)")
-        .where(item="$node_b.$property_1", operator="=", expression="$node_a.$property_2")
+        .where(item="$node_a", operator=WhereOperator.LABEL_FILTER, expression="$label_2")
+        .match()
+        .node(labels="$label_1", variable="$node_b")
+        .where(item="$node_b.$property_1", operator=WhereOperator.EQUAL, expression="$node_a.$property_2")
         .create()
         .node(variable="$from_node")
         .to(relationship_type="$relationship_type")

--- a/gqlalchemy/loaders.py
+++ b/gqlalchemy/loaders.py
@@ -28,7 +28,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from dataclasses import dataclass, field
 from dacite import from_dict
-from gqlalchemy.query_builder import WhereOperator
+from gqlalchemy.query_builder import Operator
 from pyarrow import fs
 from typing import List, Dict, Any, Optional, Union
 import pyarrow.dataset as ds
@@ -383,10 +383,10 @@ class TableToGraphImporter:
     _TriggerQueryTemplate = Template(
         Unwind(list_expression="createdVertices", variable="$node_a")
         .with_(results={"$node_a": ""})
-        .where(item="$node_a", operator=WhereOperator.LABEL_FILTER, expression="$label_2")
+        .where(item="$node_a", operator=Operator.LABEL_FILTER, expression="$label_2")
         .match()
         .node(labels="$label_1", variable="$node_b")
-        .where(item="$node_b.$property_1", operator=WhereOperator.EQUAL, expression="$node_a.$property_2")
+        .where(item="$node_b.$property_1", operator=Operator.EQUAL, expression="$node_a.$property_2")
         .create()
         .node(variable="$from_node")
         .to(relationship_type="$relationship_type")

--- a/gqlalchemy/memgraph.py
+++ b/gqlalchemy/memgraph.py
@@ -539,7 +539,7 @@ class Memgraph:
             + f" AND id(end_node) = {relationship._end_node_id}"
             + f" AND id(relationship) = {relationship._id}"
             + relationship._get_cypher_set_properties("relationship")
-            + " RETURN node;"
+            + " RETURN relationship;"
         )
 
         return self.get_variable_assume_one(results, "relationship")

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -30,6 +30,7 @@ from .exceptions import (
     GQLAlchemyTooLargeTupleInResultQuery,
     GQLAlchemyMissingOrder,
     GQLAlchemyOrderByTypeError,
+    GQLAlchemyOperatorTypeError,
 )
 
 
@@ -194,6 +195,9 @@ class WhereConditionPartialQuery(PartialQuery):
         literal = kwargs.get(WhereConditionPartialQuery._LITERAL)
         value = kwargs.get(WhereConditionPartialQuery._EXPRESSION)
 
+        if isinstance(operator, str) and operator not in WhereOperator._value2member_map_:
+            raise GQLAlchemyOperatorTypeError(clause=self.type)
+
         if value is None:
             if literal is None:
                 raise GQLAlchemyLiteralAndExpressionMissingInWhere
@@ -203,7 +207,7 @@ class WhereConditionPartialQuery(PartialQuery):
             raise GQLAlchemyExtraKeywordArgumentsInWhere
 
         return ("" if operator in [WhereOperator.LABEL_FILTER, ":"] else " ").join(
-            [item, operator if operator in WhereOperator._value2member_map_ else operator.value, value]
+            [item, operator if isinstance(operator, str) else operator.value, value]
         )
 
 
@@ -580,6 +584,9 @@ class SetPartialQuery(PartialQuery):
         literal = kwargs.get(SetPartialQuery._LITERAL)
         value = kwargs.get(SetPartialQuery._EXPRESSION)
 
+        if isinstance(operator, str) and operator not in SetOperator._value2member_map_:
+            raise GQLAlchemyOperatorTypeError(clause=self.type)
+
         if value is None:
             if literal is None:
                 raise GQLAlchemyLiteralAndExpressionMissingInSet
@@ -591,7 +598,7 @@ class SetPartialQuery(PartialQuery):
         return ("" if operator in [SetOperator.LABEL_FILTER, ":"] else " ").join(
             [
                 item,
-                operator if operator in SetOperator._value2member_map_ else operator.value,
+                operator if isinstance(operator, str) else operator.value,
                 value,
             ]
         )

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -21,11 +21,9 @@ from .graph_algorithms.integrated_algorithms import IntegratedAlgorithm
 from .utilities import to_cypher_labels, to_cypher_properties, to_cypher_value
 from .models import Node, Relationship
 from .exceptions import (
-    GQLAlchemyExtraKeywordArgumentsInSet,
+    GQLAlchemyExtraKeywordArguments,
     GQLAlchemyInstantiationError,
-    GQLAlchemyLiteralAndExpressionMissingInSet,
-    GQLAlchemyExtraKeywordArgumentsInWhere,
-    GQLAlchemyLiteralAndExpressionMissingInWhere,
+    GQLAlchemyLiteralAndExpressionMissing,
     GQLAlchemyResultQueryTypeError,
     GQLAlchemyTooLargeTupleInResultQuery,
     GQLAlchemyMissingOrder,
@@ -80,15 +78,17 @@ class Where(Enum):
     NOT = 5
 
 
-class WhereOperator(Enum):
+class Operator(Enum):
+    ASSIGNMENT = "="
     EQUAL = "="
-    NOT_EQUAL = "!="
-    INEQUAL = "<>"
-    LESS_THAN = "<"
-    GREATER_THAN = ">"
-    LEQ_THAN = "<="
     GEQ_THAN = ">="
+    GREATER_THAN = ">"
+    INEQUAL = "<>"
     LABEL_FILTER = ":"
+    LESS_THAN = "<"
+    LEQ_THAN = "<="
+    NOT_EQUAL = "!="
+    INCREMENT = "+="
 
 
 class Order(Enum):
@@ -96,12 +96,6 @@ class Order(Enum):
     ASCENDING = 2
     DESC = 3
     DESCENDING = 4
-
-
-class SetOperator(Enum):
-    ASSIGNMENT = "="
-    INCREMENT = "+="
-    LABEL_FILTER = ":"
 
 
 class NoVariablesMatchedException(Exception):
@@ -180,9 +174,7 @@ class WhereConditionPartialQuery(PartialQuery):
     _LITERAL = "literal"
     _EXPRESSION = "expression"
 
-    def __init__(
-        self, item: str, operator: WhereOperator, keyword: Where = Where.WHERE, is_negated: bool = False, **kwargs
-    ):
+    def __init__(self, item: str, operator: Operator, keyword: Where = Where.WHERE, is_negated: bool = False, **kwargs):
         super().__init__(type=keyword.name if not is_negated else f"{keyword.name} {Where.NOT.name}")
         self.query = self._build_where_query(item=item, operator=operator, **kwargs)
 
@@ -190,59 +182,65 @@ class WhereConditionPartialQuery(PartialQuery):
         """Constructs a where partial query."""
         return f" {self.type} {self.query} "
 
-    def _build_where_query(self, item: str, operator: WhereOperator, **kwargs) -> "DeclarativeBase":
+    def _build_where_query(self, item: str, operator: Operator, **kwargs) -> "DeclarativeBase":
         """Builds parts of a WHERE Cypher query divided by the boolean operators."""
         literal = kwargs.get(WhereConditionPartialQuery._LITERAL)
         value = kwargs.get(WhereConditionPartialQuery._EXPRESSION)
 
-        if isinstance(operator, str) and operator not in WhereOperator._value2member_map_:
+        operator_str = operator.value if isinstance(operator, Operator) else operator
+
+        if operator_str not in Operator._value2member_map_:
             raise GQLAlchemyOperatorTypeError(clause=self.type)
 
         if value is None:
             if literal is None:
-                raise GQLAlchemyLiteralAndExpressionMissingInWhere
+                raise GQLAlchemyLiteralAndExpressionMissing(clause=self.type)
 
             value = to_cypher_value(literal)
         elif literal is not None:
-            raise GQLAlchemyExtraKeywordArgumentsInWhere
+            raise GQLAlchemyExtraKeywordArguments(clause=self.type)
 
-        return ("" if operator in [WhereOperator.LABEL_FILTER, ":"] else " ").join(
-            [item, operator if isinstance(operator, str) else operator.value, value]
+        return ("" if operator_str == Operator.LABEL_FILTER.value else " ").join(
+            [
+                item,
+                operator_str,
+                value,
+            ]
         )
 
 
 class WhereNotConditionPartialQuery(WhereConditionPartialQuery):
-    def __init__(self, item: str, operator: WhereOperator, keyword: Where = Where.WHERE, **kwargs):
+    def __init__(self, item: str, operator: Operator, keyword: Where = Where.WHERE, **kwargs):
         super().__init__(item=item, operator=operator, keyword=keyword, is_negated=True, **kwargs)
 
 
 class AndWhereConditionPartialQuery(WhereConditionPartialQuery):
-    def __init__(self, item: str, operator: WhereOperator, **kwargs):
+    def __init__(self, item: str, operator: Operator, **kwargs):
         super().__init__(item=item, operator=operator, keyword=Where.AND, **kwargs)
 
 
 class AndNotWhereConditionPartialQuery(WhereNotConditionPartialQuery):
-    def __init__(self, item: str, operator: WhereOperator, **kwargs):
+    def __init__(self, item: str, operator: Operator, **kwargs):
         super().__init__(item=item, operator=operator, keyword=Where.AND, **kwargs)
 
 
 class OrWhereConditionPartialQuery(WhereConditionPartialQuery):
-    def __init__(self, item: str, operator: WhereOperator, **kwargs):
+    def __init__(self, item: str, operator: Operator, **kwargs):
         super().__init__(item=item, operator=operator, keyword=Where.OR, **kwargs)
 
 
 class OrNotWhereConditionPartialQuery(WhereNotConditionPartialQuery):
-    def __init__(self, item: str, operator: WhereOperator, **kwargs):
+    def __init__(self, item: str, operator: Operator, **kwargs):
         super().__init__(item=item, operator=operator, keyword=Where.OR, **kwargs)
 
 
 class XorWhereConditionPartialQuery(WhereConditionPartialQuery):
-    def __init__(self, item: str, operator: WhereOperator, **kwargs):
+    def __init__(self, item: str, operator: Operator, **kwargs):
         super().__init__(item=item, operator=operator, keyword=Where.XOR, **kwargs)
 
 
 class XorNotWhereConditionPartialQuery(WhereNotConditionPartialQuery):
-    def __init__(self, item: str, operator: WhereOperator, **kwargs):
+    def __init__(self, item: str, operator: Operator, **kwargs):
         super().__init__(item=item, operator=operator, keyword=Where.XOR, **kwargs)
 
 
@@ -570,7 +568,7 @@ class SetPartialQuery(PartialQuery):
     _LITERAL = "literal"
     _EXPRESSION = "expression"
 
-    def __init__(self, item: str, operator: SetOperator, **kwargs):
+    def __init__(self, item: str, operator: Operator, **kwargs):
         super().__init__(DeclarativeBaseTypes.SET)
 
         self.query = self._build_set_query(item=item, operator=operator, **kwargs)
@@ -579,26 +577,28 @@ class SetPartialQuery(PartialQuery):
         """Constructs a set partial query."""
         return f" {self.type} {self.query}"
 
-    def _build_set_query(self, item: str, operator: SetOperator, **kwargs) -> "DeclarativeBase":
+    def _build_set_query(self, item: str, operator: Operator, **kwargs) -> "DeclarativeBase":
         """Builds parts of a SET Cypher query divided by the boolean operators."""
         literal = kwargs.get(SetPartialQuery._LITERAL)
         value = kwargs.get(SetPartialQuery._EXPRESSION)
 
-        if isinstance(operator, str) and operator not in SetOperator._value2member_map_:
+        operator_str = operator.value if isinstance(operator, Operator) else operator
+
+        if operator_str not in Operator._value2member_map_:
             raise GQLAlchemyOperatorTypeError(clause=self.type)
 
         if value is None:
             if literal is None:
-                raise GQLAlchemyLiteralAndExpressionMissingInSet
+                raise GQLAlchemyLiteralAndExpressionMissing(clause=self.type)
 
             value = to_cypher_value(literal)
         elif literal is not None:
-            raise GQLAlchemyExtraKeywordArgumentsInSet
+            raise GQLAlchemyExtraKeywordArguments(clause=self.type)
 
-        return ("" if operator in [SetOperator.LABEL_FILTER, ":"] else " ").join(
+        return ("" if operator_str == Operator.LABEL_FILTER.value else " ").join(
             [
                 item,
-                operator if isinstance(operator, str) else operator.value,
+                operator_str,
                 value,
             ]
         )
@@ -787,7 +787,7 @@ class DeclarativeBase(ABC):
 
         return self
 
-    def where(self, item: str, operator: WhereOperator, **kwargs) -> "DeclarativeBase":
+    def where(self, item: str, operator: Operator, **kwargs) -> "DeclarativeBase":
         """Creates a WHERE statement Cypher partial query.
 
         Args:
@@ -828,7 +828,7 @@ class DeclarativeBase(ABC):
 
         return self
 
-    def where_not(self, item: str, operator: WhereOperator, **kwargs) -> "DeclarativeBase":
+    def where_not(self, item: str, operator: Operator, **kwargs) -> "DeclarativeBase":
         """Creates a WHERE NOT statement Cypher partial query.
 
         Args:
@@ -856,7 +856,7 @@ class DeclarativeBase(ABC):
 
         return self
 
-    def and_where(self, item: str, operator: WhereOperator, **kwargs) -> "DeclarativeBase":
+    def and_where(self, item: str, operator: Operator, **kwargs) -> "DeclarativeBase":
         """Creates an AND statement as a part of WHERE Cypher partial query.
 
         Args:
@@ -880,7 +880,7 @@ class DeclarativeBase(ABC):
 
         return self
 
-    def and_not_where(self, item: str, operator: WhereOperator, **kwargs) -> "DeclarativeBase":
+    def and_not_where(self, item: str, operator: Operator, **kwargs) -> "DeclarativeBase":
         """Creates an AND NOT statement as a part of WHERE Cypher partial query.
 
         Args:
@@ -904,7 +904,7 @@ class DeclarativeBase(ABC):
 
         return self
 
-    def or_where(self, item: str, operator: WhereOperator, **kwargs) -> "DeclarativeBase":
+    def or_where(self, item: str, operator: Operator, **kwargs) -> "DeclarativeBase":
         """Creates an OR statement as a part of WHERE Cypher partial query.
 
         Args:
@@ -928,7 +928,7 @@ class DeclarativeBase(ABC):
 
         return self
 
-    def or_not_where(self, item: str, operator: WhereOperator, **kwargs) -> "DeclarativeBase":
+    def or_not_where(self, item: str, operator: Operator, **kwargs) -> "DeclarativeBase":
         """Creates an OR NOT statement as a part of WHERE Cypher partial query.
 
         Args:
@@ -952,7 +952,7 @@ class DeclarativeBase(ABC):
 
         return self
 
-    def xor_where(self, item: str, operator: WhereOperator, **kwargs) -> "DeclarativeBase":
+    def xor_where(self, item: str, operator: Operator, **kwargs) -> "DeclarativeBase":
         """Creates an XOR statement as a part of WHERE Cypher partial query.
 
         Args:
@@ -976,7 +976,7 @@ class DeclarativeBase(ABC):
 
         return self
 
-    def xor_not_where(self, item: str, operator: WhereOperator, **kwargs) -> "DeclarativeBase":
+    def xor_not_where(self, item: str, operator: Operator, **kwargs) -> "DeclarativeBase":
         """Creates an XOR NOT statement as a part of WHERE Cypher partial query.
 
         Args:
@@ -1221,7 +1221,7 @@ class DeclarativeBase(ABC):
             return result[retrieve]
         return result
 
-    def set_(self, item: str, operator: SetOperator, **kwargs):
+    def set_(self, item: str, operator: Operator, **kwargs):
         """Creates a SET statement Cypher partial query.
 
         Args:

--- a/tests/docs/test_ogm.py
+++ b/tests/docs/test_ogm.py
@@ -1,4 +1,5 @@
 from gqlalchemy import Memgraph, Node, Relationship, Field, match
+from gqlalchemy.query_builder import WhereOperator
 from typing import Optional
 
 db = Memgraph()
@@ -65,7 +66,11 @@ class TestMapNodesAndRelationships:
         ).save(db)
 
         result = next(
-            match().node("Streamer", variable="s").where(item="s.id", operator="=", literal="7").return_().execute()
+            match()
+            .node("Streamer", variable="s")
+            .where(item="s.id", operator=WhereOperator.EQUAL, literal="7")
+            .return_()
+            .execute()
         )["s"]
 
         assert result.id == streamer.id
@@ -113,7 +118,11 @@ class TestSaveNodesAndRelationships:
         language = Language(name="en").save(db)
 
         result = next(
-            match().node("UserSave", variable="u").where(item="u.id", operator="=", literal="3").return_().execute()
+            match()
+            .node("UserSave", variable="u")
+            .where(item="u.id", operator=WhereOperator.EQUAL, literal="3")
+            .return_()
+            .execute()
         )["u"]
 
         assert result.id == user.id
@@ -131,7 +140,11 @@ class TestSaveNodesAndRelationships:
         db.save_node(language)
 
         result = next(
-            match().node("UserSave", variable="u").where(item="u.id", operator="=", literal="4").return_().execute()
+            match()
+            .node("UserSave", variable="u")
+            .where(item="u.id", operator=WhereOperator.EQUAL, literal="4")
+            .return_()
+            .execute()
         )["u"]
 
         assert result.id == user.id

--- a/tests/docs/test_ogm.py
+++ b/tests/docs/test_ogm.py
@@ -1,5 +1,5 @@
 from gqlalchemy import Memgraph, Node, Relationship, Field, match
-from gqlalchemy.query_builder import WhereOperator
+from gqlalchemy.query_builder import Operator
 from typing import Optional
 
 db = Memgraph()
@@ -68,7 +68,7 @@ class TestMapNodesAndRelationships:
         result = next(
             match()
             .node("Streamer", variable="s")
-            .where(item="s.id", operator=WhereOperator.EQUAL, literal="7")
+            .where(item="s.id", operator=Operator.EQUAL, literal="7")
             .return_()
             .execute()
         )["s"]
@@ -120,7 +120,7 @@ class TestSaveNodesAndRelationships:
         result = next(
             match()
             .node("UserSave", variable="u")
-            .where(item="u.id", operator=WhereOperator.EQUAL, literal="3")
+            .where(item="u.id", operator=Operator.EQUAL, literal="3")
             .return_()
             .execute()
         )["u"]
@@ -142,7 +142,7 @@ class TestSaveNodesAndRelationships:
         result = next(
             match()
             .node("UserSave", variable="u")
-            .where(item="u.id", operator=WhereOperator.EQUAL, literal="4")
+            .where(item="u.id", operator=Operator.EQUAL, literal="4")
             .return_()
             .execute()
         )["u"]

--- a/tests/docs/test_query_builder.py
+++ b/tests/docs/test_query_builder.py
@@ -16,7 +16,7 @@ from unittest.mock import patch
 
 from gqlalchemy import match, call, create, merge
 from gqlalchemy.memgraph import Memgraph
-from gqlalchemy.query_builder import WhereOperator
+from gqlalchemy.query_builder import Operator
 
 
 def test_call_procedures_1(memgraph):
@@ -121,8 +121,8 @@ def test_filter_data_1(memgraph):
         .node("Person", variable="p1")
         .to("FRIENDS_WITH")
         .node("Person", variable="p2")
-        .where(item="n.name", operator=WhereOperator.EQUAL, literal="Ron")
-        .or_where(item="m.id", operator=WhereOperator.EQUAL, literal=0)
+        .where(item="n.name", operator=Operator.EQUAL, literal="Ron")
+        .or_where(item="m.id", operator=Operator.EQUAL, literal=0)
         .return_()
     )
 

--- a/tests/docs/test_query_builder.py
+++ b/tests/docs/test_query_builder.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 from gqlalchemy import match, call, create, merge
 from gqlalchemy.memgraph import Memgraph
+from gqlalchemy.query_builder import WhereOperator
 
 
 def test_call_procedures_1(memgraph):
@@ -120,8 +121,8 @@ def test_filter_data_1(memgraph):
         .node("Person", variable="p1")
         .to("FRIENDS_WITH")
         .node("Person", variable="p2")
-        .where(item="n.name", operator="=", literal="Ron")
-        .or_where(item="m.id", operator="=", literal=0)
+        .where(item="n.name", operator=WhereOperator.EQUAL, literal="Ron")
+        .or_where(item="m.id", operator=WhereOperator.EQUAL, literal=0)
         .return_()
     )
 

--- a/tests/memgraph/test_query_builder.py
+++ b/tests/memgraph/test_query_builder.py
@@ -21,6 +21,7 @@ from gqlalchemy.exceptions import (
     GQLAlchemyExtraKeywordArgumentsInWhere,
     GQLAlchemyResultQueryTypeError,
     GQLAlchemyTooLargeTupleInResultQuery,
+    GQLAlchemyOperatorTypeError,
 )
 import pytest
 from gqlalchemy import (
@@ -422,6 +423,19 @@ def test_where_label_without_operator_enum(memgraph):
         query_builder.execute()
 
     mock.assert_called_with(expected_query)
+
+
+def test_where_label_with_rand_string_operator(memgraph):
+    with pytest.raises(GQLAlchemyOperatorTypeError):
+        (
+            QueryBuilder()
+            .match()
+            .node(labels="L1", variable="n")
+            .to(relationship_type="TO")
+            .node(labels="L2", variable="m")
+            .where(item="n", operator="heyhey", expression="Node")
+            .return_()
+        )
 
 
 def test_where_label(memgraph):
@@ -1541,6 +1555,11 @@ def test_set_label_without_operator_enum(memgraph):
     expected_query = " SET a:L1"
 
     assert query_builder.construct_query() == expected_query
+
+
+def test_set_label_with_rand_operator(memgraph):
+    with pytest.raises(GQLAlchemyOperatorTypeError):
+        QueryBuilder().set_(item="a", operator="heyhey", expression="L1")
 
 
 def test_set_label(memgraph):


### PR DESCRIPTION
### Description

I created `Operator` `Enum`. This Enum holds operators for `SET` and `WHERE` clauses. I added all operators that are a part of [`partialComparisonExpression` in the Cypher grammar](https://github.com/memgraph/memgraph/blob/69eca9b0437a3370d13a01669b8eabbcc9ff9599/src/query/frontend/opencypher/grammar/Cypher.g4#L259).  I updated all tests accordingly and left a couple of examples showing that the previous solution with a simple string operator works (backward compatibility).

Not sure if the operators should be used across the documentation (how-to guides and docstrings) or a simple string - it is a question for both `WHERE` and `SET` clauses. @g-despot ?

### Pull request type

Please delete options that are not relevant.

- [x] Bugfix
- [x] Code style update (formatting, renaming)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
