### PR TITLE
[develop < T0106] fix @property being optional when they are not

### DIFF
--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -245,7 +245,7 @@ class XorNotWhereConditionPartialQuery(WhereNotConditionPartialQuery):
 
 
 class NodePartialQuery(PartialQuery):
-    def __init__(self, variable: str, labels: str, properties: str):
+    def __init__(self, variable: Optional[str], labels: str, properties: str):
         super().__init__(DeclarativeBaseTypes.NODE)
 
         self._variable = variable
@@ -254,15 +254,15 @@ class NodePartialQuery(PartialQuery):
 
     @property
     def variable(self) -> str:
-        return self._variable if self._variable is not None else ""
+        return "" if self._variable is None else self._variable
 
     @property
     def labels(self) -> str:
-        return self._labels if self._labels is not None else ""
+        return self._labels
 
     @property
     def properties(self) -> str:
-        return self._properties if self._properties is not None else ""
+        return self._properties
 
     def construct_query(self) -> str:
         """Constructs a node partial query."""
@@ -273,9 +273,9 @@ class RelationshipPartialQuery(PartialQuery):
     def __init__(
         self,
         variable: Optional[str],
-        labels: Optional[str],
-        algorithm: Optional[str],
-        properties: Optional[str],
+        labels: str,
+        algorithm: str,
+        properties: str,
         directed: bool,
         from_: bool,
     ):
@@ -294,18 +294,18 @@ class RelationshipPartialQuery(PartialQuery):
 
     @property
     def labels(self) -> str:
-        return "" if self._labels is None else self._labels
+        return self._labels
 
     @property
     def algorithm(self) -> str:
-        return "" if self._algorithm is None else self._algorithm
+        return self._algorithm
 
     @property
     def properties(self) -> str:
-        return "" if self._properties is None else self._properties
+        return self._properties
 
     def construct_query(self) -> str:
-        """Constructs an relationship partial query."""
+        """Constructs a relationship partial query."""
         relationship_query = f"{self.variable}{self.labels}{self.algorithm}{self.properties}"
 
         if not self.directed:
@@ -446,7 +446,7 @@ class DeletePartialQuery(PartialQuery):
 
     @property
     def variable_expressions(self) -> str:
-        return self._variable_expressions if self._variable_expressions is not None else ""
+        return self._variable_expressions
 
     def construct_query(self) -> str:
         """Creates a DELETE statement Cypher partial query."""
@@ -461,7 +461,7 @@ class RemovePartialQuery(PartialQuery):
 
     @property
     def items(self) -> str:
-        return self._items if self._items is not None else ""
+        return self._items
 
     def construct_query(self) -> str:
         """Creates a REMOVE statement Cypher partial query."""

--- a/gqlalchemy/query_builder.py
+++ b/gqlalchemy/query_builder.py
@@ -248,13 +248,13 @@ class NodePartialQuery(PartialQuery):
     def __init__(self, variable: Optional[str], labels: str, properties: str):
         super().__init__(DeclarativeBaseTypes.NODE)
 
-        self._variable = variable
+        self._variable = "" if variable is None else variable
         self._labels = labels
         self._properties = properties
 
     @property
     def variable(self) -> str:
-        return "" if self._variable is None else self._variable
+        return self._variable
 
     @property
     def labels(self) -> str:
@@ -282,7 +282,7 @@ class RelationshipPartialQuery(PartialQuery):
         super().__init__(DeclarativeBaseTypes.RELATIONSHIP)
 
         self.directed = directed
-        self._variable = variable
+        self._variable = "" if variable is None else variable
         self._labels = labels
         self._algorithm = algorithm
         self._properties = properties
@@ -290,7 +290,7 @@ class RelationshipPartialQuery(PartialQuery):
 
     @property
     def variable(self) -> str:
-        return "" if self._variable is None else self._variable
+        return self._variable
 
     @property
     def labels(self) -> str:


### PR DESCRIPTION
### Description

After @BorisTasevski noted checking for `None` in a property that is not of type `Optional[...]` is not consistent, I looked at other `@property` uses. 
- for `NodePartialQuery` and `RelationshipPartialQuery` value argument, which is optional, I turned the double negative if-else expression into positive logic, as we previously discussed was easier to understand.
- for arguments `labels` and `properties`, along with `RemovePartialQuery` and `DeletePartialQuery` arguments, I removed the checking and Optional support since they go through their respective `to_cypher_` methods first, which assigns them an empty string if they are `None` to begin with. This is something to discuss, if you think we should still support this for flexibility (e.g. if we were to change `to_cypher_properties` method), let me know.

One other thing I noticed: `RelationshipPartialQuery` receives a `labels` argument, but we agreed on naming the relationship labels as `types`. and also, there must be exactly one so it should be named `type`. Unfortunately this would be a breaking change.

### Pull request type

- [x] Code style update (formatting, renaming)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

######################################

### Reviewer checklist (the reviewer checks this part)
- [ ] Core feature implementation
- [ ] Tests
- [ ] Code documentation
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)

######################################
