### PR TITLE
[develop < T0109-GA] Remove excess Iterable type

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ When building a Cypher query, you can use a set of methods that are wrappers aro
 
 ```python
 from gqlalchemy import create, match
+from gqlalchemy.query_builder import Operator
 
 query_create = create()
         .node(labels="Person", name="Leslie")
-        .to(edge_label="FRIENDS_WITH")
+        .to(relationship_type="FRIENDS_WITH")
         .node(labels="Person", name="Ron")
         .execute()
 
@@ -102,8 +103,8 @@ query_match = match()
         .node(labels="Person", variable="p1")
         .to()
         .node(labels="Person", variable="p2")
-        .where(item="p1.name", operator="=", literal="Leslie")
-        .return_({"p1":"p1"})
+        .where(item="p1.name", operator=Operator.EQUAL, literal="Leslie")
+        .return_(results=["p1", ("p2", "second")])
         .execute()
 ```
 </details>

--- a/gqlalchemy/query_builders/declarative_base.py
+++ b/gqlalchemy/query_builders/declarative_base.py
@@ -1089,7 +1089,16 @@ class DeclarativeBase(ABC):
         return self
 
     def with_(
-        self, results: Optional[Union[str, Tuple[str, str], Iterable[Union[str, Tuple[str, str]]]]] = None
+        self,
+        results: Optional[
+            Union[
+                str,
+                Tuple[str, str],
+                Dict[str, str],
+                List[Union[str, Tuple[str, str]]],
+                Set[Union[str, Tuple[str, str]]],
+            ]
+        ] = None,
     ) -> "DeclarativeBase":
         """Chain together parts of a query, piping the results from one to be
         used as starting points or criteria in the next.
@@ -1183,7 +1192,16 @@ class DeclarativeBase(ABC):
         return self
 
     def yield_(
-        self, results: Optional[Union[str, Tuple[str, str], Iterable[Union[str, Tuple[str, str]]]]] = None
+        self,
+        results: Optional[
+            Union[
+                str,
+                Tuple[str, str],
+                Dict[str, str],
+                List[Union[str, Tuple[str, str]]],
+                Set[Union[str, Tuple[str, str]]],
+            ]
+        ] = None,
     ) -> "DeclarativeBase":
         """Yield data from the query.
 
@@ -1213,7 +1231,16 @@ class DeclarativeBase(ABC):
         return self
 
     def return_(
-        self, results: Optional[Union[str, Tuple[str, str], Iterable[Union[str, Tuple[str, str]]]]] = None
+        self,
+        results: Optional[
+            Union[
+                str,
+                Tuple[str, str],
+                Dict[str, str],
+                List[Union[str, Tuple[str, str]]],
+                Set[Union[str, Tuple[str, str]]],
+            ]
+        ] = None,
     ) -> "DeclarativeBase":
         """Return data from the query.
 

--- a/gqlalchemy/query_builders/declarative_base.py
+++ b/gqlalchemy/query_builders/declarative_base.py
@@ -15,7 +15,7 @@
 import re
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
 
 from gqlalchemy.exceptions import (
     GQLAlchemyExtraKeywordArguments,

--- a/gqlalchemy/query_builders/declarative_base.py
+++ b/gqlalchemy/query_builders/declarative_base.py
@@ -265,7 +265,7 @@ class RelationshipPartialQuery(PartialQuery):
     def __init__(
         self,
         variable: Optional[str],
-        labels: str,
+        relationship_type: str,
         algorithm: str,
         properties: str,
         directed: bool,
@@ -275,7 +275,7 @@ class RelationshipPartialQuery(PartialQuery):
 
         self.directed = directed
         self._variable = "" if variable is None else variable
-        self._labels = labels
+        self._relationship_type = relationship_type
         self._algorithm = algorithm
         self._properties = properties
         self._from = from_
@@ -285,8 +285,8 @@ class RelationshipPartialQuery(PartialQuery):
         return self._variable
 
     @property
-    def labels(self) -> str:
-        return self._labels
+    def relationship_type(self) -> str:
+        return self._relationship_type
 
     @property
     def algorithm(self) -> str:
@@ -298,7 +298,7 @@ class RelationshipPartialQuery(PartialQuery):
 
     def construct_query(self) -> str:
         """Constructs a relationship partial query."""
-        relationship_query = f"{self.variable}{self.labels}{self.algorithm}{self.properties}"
+        relationship_query = f"{self.variable}{self.relationship_type}{self.algorithm}{self.properties}"
 
         if not self.directed:
             relationship_query = f"-[{relationship_query}]-"
@@ -796,7 +796,7 @@ class DeclarativeBase(ABC):
         self._query.append(
             RelationshipPartialQuery(
                 variable=variable,
-                labels=type_str,
+                relationship_type=type_str,
                 algorithm="" if algorithm is None else str(algorithm),
                 properties=properties_str,
                 directed=bool(directed),
@@ -847,7 +847,7 @@ class DeclarativeBase(ABC):
         self._query.append(
             RelationshipPartialQuery(
                 variable=variable,
-                labels=type_str,
+                relationship_type=type_str,
                 algorithm="" if algorithm is None else str(algorithm),
                 properties=properties_str,
                 directed=bool(directed),


### PR DESCRIPTION
### Description

I changed Iterable to correct argument type. It was accidentally left unchanged from the previous [PR](https://github.com/memgraph/gqlalchemy/pull/146). 

### Pull request type

- [x] Bugfix

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

