### PR TITLE
Fix raised GQLAlchemyWaitForConnectionError error in conneciton_handler

### DIFF
--- a/gqlalchemy/exceptions.py
+++ b/gqlalchemy/exceptions.py
@@ -232,7 +232,7 @@ def connection_handler(func, delay: float = 0.01, timeout: float = 5.0, backoff:
             except Exception as ex:
                 time.sleep(current_delay)
                 if time.perf_counter() - start_time >= timeout:
-                    raise GQLAlchemyWaitForConnectionError(ex)
+                    raise GQLAlchemyWaitForConnectionError from ex
 
                 current_delay *= backoff
 


### PR DESCRIPTION
### Description

`exceptions.connection_handler` raises `GQLAlchemyWaitForConnectionError` after a timeout has passed. The exception raised passes an argument but `GQLAlchemyWaitForConnectionError.__init__` doesn't take any, as the exception message is predefined. The fix is to use the `raise from` statement to forward the exception.

### Pull request type

Please delete options that are not relevant.

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring with functional or API changes
- [ ] Refactoring without functional or API changes
- [ ] Build or packaging related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

######################################

### Reviewer checklist (the reviewer checks this part)
- [ ] Core feature implementation
- [ ] Tests
- [ ] Code documentation
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)

######################################
