### PR TITLE
Fix links for table data importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,13 @@ db.start_stream(stream)
 
 You can translate table data from a file to graph data and import it to Memgraph. Currently, we support reading of CSV, Parquet, ORC and IPC/Feather/Arrow file formats via the PyArrow package.
 
-Read all about it in [table to graph importer how-to guide](https://memgraph.com/docs/gqlalchemy/how-to-guides/loaders/table-to-graph-importer).
+Read all about it in [table to graph importer how-to guide](https://memgraph.com/docs/gqlalchemy/how-to-guides/table-to-graph-importer).
 
 **Make a custom file system importer**
 
 If you want to read from a file system not currently supported by GQLAlchemy, or use a file type currently not readable, you can implement your own by extending abstract classes `FileSystemHandler` and `DataLoader`, respectively.
 
-Read all about it in [custom file system importer how-to guide](https://memgraph.com/docs/gqlalchemy/how-to-guides/loaders/custom-file-system-importer).
+Read all about it in [custom file system importer how-to guide](https://memgraph.com/docs/gqlalchemy/how-to-guides/custom-file-system-importer).
 
 </details>
 


### PR DESCRIPTION
### Description

Someone probably changed the link for table importer how-to guides, which now doesn't include `/loaders/`. Some of the how-to guides contain the category, and some don't.

### Pull request type

- [x] Bugfix

### Related issues

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- x ] New and existing unit tests pass locally with my changes

######################################

### Reviewer checklist (the reviewer checks this part)
- [ ] Core feature implementation
- [ ] Tests
- [ ] Code documentation
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)

######################################
