### PR TITLE
[develop < T0123] Graph project implementation

### DIFF
--- a/gqlalchemy/query_builders/memgraph_query_builder.py
+++ b/gqlalchemy/query_builders/memgraph_query_builder.py
@@ -31,7 +31,7 @@ from gqlalchemy.query_builders.declarative_base import (  # noqa F401
 )
 from gqlalchemy.vendors.database_client import DatabaseClient
 from gqlalchemy.vendors.memgraph import Memgraph
-from gqlalchemy.utilities import CypherVariable
+from gqlalchemy.utilities import CypherVariable, CypherNode, CypherRelationship, RelationshipDirection
 
 
 class MemgraphQueryBuilderTypes(DeclarativeBaseTypes):
@@ -92,19 +92,10 @@ class QueryBuilder(DeclarativeBase):
         Returns:
             a string representing a MATCH query for a path with given node labels and relationship types.
         """
-        query = " MATCH p="
-        node = "()" if node_label is None else f"(:{node_label.upper()})"
+        node = CypherNode(node_label)
 
-        query += node + "-"
-
-        if isinstance(relationship_types, str):
-            query += f"[:{relationship_types}]"
-        elif isinstance(relationship_types, Iterable):
-            rels = " | :".join(relationship_types)
-            query += f"[:{rels}]"
-
-        # directed is OK only if we have single label, homogenous graphs
-        query += "->" + node
+        # directed is OK only if we have single label, homogenous graphs (current implementation)
+        query = f" MATCH p={node}{CypherRelationship(relationship_types, RelationshipDirection.RIGHT)}{node}"
 
         return query
 

--- a/gqlalchemy/query_builders/memgraph_query_builder.py
+++ b/gqlalchemy/query_builders/memgraph_query_builder.py
@@ -89,8 +89,9 @@ class QueryBuilder(DeclarativeBase):
         """Constructs a MATCH query defining a subgraph using one or two node labels and relationship types.
 
         Args:
-            node_labels: If string, used for both sides of the relationship, if list of two, used
+            node_labels: If string, used for both sides of the relationship, if list of two, used in order.
             relationship_types: A string or iterable of types of relationships used in the subgraph.
+            relationship_direction: Enum representing direction.
 
         Returns:
             a string representing a MATCH query for a path with given node labels and relationship types.
@@ -127,8 +128,9 @@ class QueryBuilder(DeclarativeBase):
               format `query_module.procedure`.
             arguments: A string representing the arguments of the procedure in
               text format.
-            node_label: Label of nodes to be used in the subgraph.
+            node_labels: Labels that define the subgraph.
             relationship_types: Types of relationships to be used in the subgraph.
+            relationship_direction: Direction of the relationship.
             subgraph_query: Optional way to define the subgraph via a Cypher MATCH clause.
 
         Returns:

--- a/gqlalchemy/query_builders/memgraph_query_builder.py
+++ b/gqlalchemy/query_builders/memgraph_query_builder.py
@@ -97,14 +97,14 @@ class QueryBuilder(DeclarativeBase):
             a string representing a MATCH query for a path with given node labels and relationship types.
         """
         if not node_labels or isinstance(node_labels, str):
-            node1 = node2 = CypherNode(node_labels)
+            node1 = second_node = CypherNode(node_labels)
         else:
             if len(node_labels) > 2:
                 raise ValueError("only two node labels are permitted, one for outgoing node and one for incoming node.")
-            node1 = CypherNode(node_labels[0])
-            node2 = CypherNode(node_labels[1])
+            first_node = CypherNode(node_labels[0])
+            second_node = CypherNode(node_labels[1])
 
-        query = f" MATCH p={node1}{CypherRelationship(relationship_types, relationship_direction)}{node2}"
+        query = f" MATCH p={first_node}{CypherRelationship(relationship_types, relationship_direction)}{second_node}"
 
         return query
 

--- a/gqlalchemy/query_builders/memgraph_query_builder.py
+++ b/gqlalchemy/query_builders/memgraph_query_builder.py
@@ -97,7 +97,7 @@ class QueryBuilder(DeclarativeBase):
             a string representing a MATCH query for a path with given node labels and relationship types.
         """
         if not node_labels or isinstance(node_labels, str):
-            node1 = second_node = CypherNode(node_labels)
+            first_node = second_node = CypherNode(node_labels)
         else:
             if len(node_labels) > 2:
                 raise ValueError("only two node labels are permitted, one for outgoing node and one for incoming node.")

--- a/gqlalchemy/query_builders/memgraph_query_builder.py
+++ b/gqlalchemy/query_builders/memgraph_query_builder.py
@@ -122,7 +122,7 @@ class QueryBuilder(DeclarativeBase):
         """Override of base class method to support Memgraph's subgraph functionality.
 
         Method can be called with node labels and relationship types, both being optional, which are used to construct
-        a subgraph, or if neither is provided, a subgraph query is used, which can be passed as a string representing a 
+        a subgraph, or if neither is provided, a subgraph query is used, which can be passed as a string representing a
         Cypher query defining the MATCH clause which selects the nodes and relationships to use.
 
         Args:
@@ -183,6 +183,6 @@ class ProjectPartialQuery(PartialQuery):
         And appends the WITH clause."""
         query = self.query
         location = query.index("(")
-        if query[location-1] != "=":
+        if query[location - 1] != "=":
             query = query[:location] + "p=" + query[location:]
         return f" {query} WITH project(p) AS graph "

--- a/gqlalchemy/query_builders/memgraph_query_builder.py
+++ b/gqlalchemy/query_builders/memgraph_query_builder.py
@@ -86,17 +86,14 @@ class QueryBuilder(DeclarativeBase):
         """Constructs a MATCH query defining a subgraph using zero or one node labels and relationship types.
 
         Args:
-            node_label (Optional[str], optional): node label to be used in subgraph
-            relationship_types (Optional[Union[str, Iterable[str]]], optional): types of relationships used in subgraph.
+            node_label: A string representing a node label to be used in this subgraph.
+            relationship_types: A string or iterable of types of relationships used in the subgraph.
 
         Returns:
-            str: a MATCH query for a path with given node labels and relationship types
+            a string representing a MATCH query for a path with given node labels and relationship types.
         """
         query = " MATCH p="
-        if node_label is None:
-            node = "()"
-        else:
-            node = f"(:{node_label.upper()})"
+        node = "()" if node_label is None else f"(:{node_label.upper()})"
 
         query += node + "-"
 
@@ -180,7 +177,7 @@ class ProjectPartialQuery(PartialQuery):
 
     def construct_query(self) -> str:
         """Constructs a Project partial querty. Given a Match query, adds path identifier if needed
-        And appends the WITH clause."""
+        and appends the WITH clause."""
         query = self.query
         location = query.index("(")
         if query[location - 1] != "=":

--- a/gqlalchemy/query_builders/memgraph_query_builder.py
+++ b/gqlalchemy/query_builders/memgraph_query_builder.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, Union, Tuple, Iterable
 
 from gqlalchemy.query_builders.declarative_base import (  # noqa F401
     Call,
@@ -31,6 +31,7 @@ from gqlalchemy.query_builders.declarative_base import (  # noqa F401
 )
 from gqlalchemy.vendors.database_client import DatabaseClient
 from gqlalchemy.vendors.memgraph import Memgraph
+from gqlalchemy.utilities import CypherVariable
 
 
 class MemgraphQueryBuilderTypes(DeclarativeBaseTypes):
@@ -79,8 +80,109 @@ class QueryBuilder(DeclarativeBase):
 
         return self
 
+    def construct_subgraph_query(
+        self, node_label: Optional[str] = None, relationship_types: Optional[Union[str, Iterable[str]]] = None
+    ) -> str:
+        """Constructs a MATCH query defining a subgraph using zero or one node labels and relationship types.
+
+        Args:
+            node_label (Optional[str], optional): node label to be used in subgraph
+            relationship_types (Optional[Union[str, Iterable[str]]], optional): types of relationships used in subgraph.
+
+        Returns:
+            str: a MATCH query for a path with given node labels and relationship types
+        """
+        query = " MATCH p="
+        if node_label is None:
+            node = "()"
+        else:
+            node = f"(:{node_label.upper()})"
+
+        query += node + "-"
+
+        if isinstance(relationship_types, str):
+            query += f"[:{relationship_types}]"
+        elif isinstance(relationship_types, Iterable):
+            rels = " | :".join(relationship_types)
+            query += f"[:{rels}]"
+
+        # directed is OK only if we have single label, homogenous graphs
+        query += "->" + node
+
+        return query
+
+    def call(
+        self,
+        procedure: str,
+        arguments: Optional[Union[str, Tuple[Union[str, int, float]]]] = None,
+        node_label: Optional[str] = None,
+        relationship_types: Optional[Union[str, Iterable[str]]] = None,
+        subgraph_query: str = None,
+    ) -> "DeclarativeBase":
+        """Override of base class method to support Memgraph's subgraph functionality.
+
+        Method can be called with node labels and relationship types, both being optional, which are used to construct
+        a subgraph, or if neither is provided, a subgraph query is used, which can be passed as a string representing a 
+        Cypher query defining the MATCH clause which selects the nodes and relationships to use.
+
+        Args:
+            procedure: A string representing the name of the procedure in the
+              format `query_module.procedure`.
+            arguments: A string representing the arguments of the procedure in
+              text format.
+            node_label: Label of nodes to be used in the subgraph.
+            relationship_types: Types of relationships to be used in the subgraph.
+            subgraph_query: Optional way to define the subgraph via a Cypher MATCH clause.
+
+        Returns:
+            A `DeclarativeBase` instance for constructing queries.
+
+        Examples:
+            Python: `call('export_util.json', '/home/user', "LABEL", ["TYPE1", "TYPE2"]).execute()
+            Cypher: `MATCH p=(:LABEL)-[:TYPE1 | :TYPE2]->(:LABEL) WITH project(p) AS graph
+                    CALL export_util.json(graph, '/home/user')`
+
+            or
+
+            Python: `call('export_util.json', '/home/user', subgraph_query="MATCH (:LABEL)-[:TYPE]->(:LABEL)").execute()
+            Cypher: `MATCH p=(:LABEL)-[:TYPE1]->(:LABEL) WITH project(p) AS graph
+                    CALL export_util.json(graph, '/home/user')`
+        """
+
+        if not (node_label is None and relationship_types is None):
+            subgraph_query = self.construct_subgraph_query(node_label=node_label, relationship_types=relationship_types)
+
+        if subgraph_query is not None:
+            self._query.append(ProjectPartialQuery(subgraph_query=subgraph_query))
+
+            if isinstance(arguments, str):
+                arguments = (CypherVariable(name="graph"), arguments)
+            elif isinstance(arguments, tuple):
+                arguments = (CypherVariable(name="graph"), *arguments)
+            else:
+                arguments = CypherVariable(name="graph")
+
+        super().call(procedure=procedure, arguments=arguments)
+
+        return self
+
 
 class LoadCsv(DeclarativeBase):
     def __init__(self, path: str, header: bool, row: str, connection: Optional[DatabaseClient] = None):
         super().__init__(connection)
         self._query.append(LoadCsvPartialQuery(path, header, row))
+
+
+class ProjectPartialQuery(PartialQuery):
+    def __init__(self, subgraph_query):
+        super().__init__(DeclarativeBaseTypes.MATCH)
+        self.query = subgraph_query
+
+    def construct_query(self) -> str:
+        """Constructs a Project partial querty. Given a Match query, adds path identifier if needed
+        And appends the WITH clause."""
+        query = self.query
+        location = query.index("(")
+        if query[location-1] != "=":
+            query = query[:location] + "p=" + query[location:]
+        return f" {query} WITH project(p) AS graph "

--- a/gqlalchemy/utilities.py
+++ b/gqlalchemy/utilities.py
@@ -155,7 +155,7 @@ class CypherNode(CypherObject):
 
     def __init__(self, labels: Optional[Union[str, list]] = None) -> None:
         super().__init__()
-        if isinstance(labels, str):
+        if isinstance(labels, str) and labels:
             self.labels = [labels]
         else:
             self.labels = labels

--- a/gqlalchemy/utilities.py
+++ b/gqlalchemy/utilities.py
@@ -70,7 +70,7 @@ def to_cypher_value(value: Any, config: NetworkXCypherConfig = None) -> str:
 
     value_type = type(value)
 
-    if value_type == PropertyVariable:
+    if value_type == CypherVariable:
         return str(value)
 
     if isinstance(value, (timedelta, time, datetime, date)):
@@ -134,9 +134,9 @@ def to_cypher_qm_arguments(arguments: Optional[Union[str, Tuple[Union[str, int, 
     return arguments
 
 
-class PropertyVariable:
-    """Class for support of using a variable as a node or edge property. Used
-    to avoid the quotes given to property values.
+class CypherVariable:
+    """Class for support of using a variable as value in Cypher. Used
+    to avoid the quotes given to property values and query module arguments.
     """
 
     def __init__(self, name: str) -> None:

--- a/gqlalchemy/utilities.py
+++ b/gqlalchemy/utilities.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from abc import ABC, abstractmethod
 import math
 from datetime import datetime, date, time, timedelta
 from enum import Enum
@@ -132,6 +133,72 @@ def to_cypher_qm_arguments(arguments: Optional[Union[str, Tuple[Union[str, int, 
         return ", ".join([to_cypher_value(arg) for arg in arguments])
 
     return arguments
+
+
+class CypherObject(ABC):
+    """Abstract method representing an object in cypher syntax, such as nodes
+    and relationships.
+    """
+
+    @abstractmethod
+    def __str__(self) -> str:
+        pass
+
+
+class CypherNode(CypherObject):
+    """Represents a node in Cypher syntax."""
+
+    def __init__(self, labels: Optional[Union[str, list]] = None) -> None:
+        super().__init__()
+        if isinstance(labels, str):
+            self.labels = [labels]
+        else:
+            self.labels = labels
+
+    def __str__(self) -> str:
+        if not self.labels:
+            return "()"
+
+        return "(:" + ":".join(self.labels) + ")"
+
+
+class RelationshipDirection(Enum):
+    """Defines the direction of CypherRelationship object"""
+
+    UNDIRECTED = 1
+    LEFT = 2
+    RIGHT = 3
+
+
+class CypherRelationship(CypherObject):
+    """Represents a relationship in Cypher syntax. Multiple types can not be
+    set on a relationship, only queried.
+    """
+
+    def __init__(
+        self,
+        types: Optional[Union[str, list]] = None,
+        direction: Optional[RelationshipDirection] = RelationshipDirection.UNDIRECTED,
+    ) -> None:
+        super().__init__()
+        if isinstance(types, str):
+            self.types = [types]
+        else:
+            self.types = types
+        self.direction = direction
+
+    def __str__(self) -> str:
+        if self.types:
+            cypher_relationship = "-[:" + " | :".join(self.types) + "]-"
+        else:
+            cypher_relationship = "--"
+
+        if self.direction == RelationshipDirection.LEFT:
+            return "<" + cypher_relationship
+        elif self.direction == RelationshipDirection.RIGHT:
+            return cypher_relationship + ">"
+        else:
+            return cypher_relationship
 
 
 class CypherVariable:

--- a/gqlalchemy/utilities.py
+++ b/gqlalchemy/utilities.py
@@ -168,7 +168,7 @@ class CypherNode(CypherObject):
 
 
 class RelationshipDirection(Enum):
-    """Defines the direction of CypherRelationship object"""
+    """Defines the direction of CypherRelationship object."""
 
     UNDIRECTED = 1
     LEFT = 2

--- a/gqlalchemy/utilities.py
+++ b/gqlalchemy/utilities.py
@@ -153,18 +153,25 @@ class CypherObject(ABC):
 class CypherNode(CypherObject):
     """Represents a node in Cypher syntax."""
 
-    def __init__(self, labels: Optional[Union[str, list]] = None) -> None:
+    def __init__(self, variable: str = None, labels: Optional[Union[str, list]] = None) -> None:
         super().__init__()
         if isinstance(labels, str) and labels:
-            self.labels = [labels]
+            self._labels = [labels]
         else:
-            self.labels = labels
+            self._labels = labels
+        self._variable = variable
 
     def __str__(self) -> str:
-        if not self.labels:
-            return "()"
+        s = "("
 
-        return "(:" + ":".join(self.labels) + ")"
+        if self._variable:
+            s += self._variable
+
+        if not self._labels:
+            return s + ")"
+
+        s += ":" + ":".join(self._labels) + ")"
+        return s
 
 
 class RelationshipDirection(Enum):

--- a/tests/query_builders/test_memgraph_query_builder.py
+++ b/tests/query_builders/test_memgraph_query_builder.py
@@ -52,11 +52,29 @@ def test_load_csv_no_header(memgraph):
     mock.assert_called_with(expected_query)
 
 
-def test_call_subgraph_with_labels(memgraph):
+def test_call_subgraph_with_labels_and_types(memgraph):
     label = "LABEL"
     types = ["TYPE1", "TYPE2"]
     query_builder = QueryBuilder().call("export_util.json", "/home/user", node_label=label, relationship_types=types)
     expected_query = " MATCH p=(:LABEL)-[:TYPE1 | :TYPE2]->(:LABEL) WITH project(p) AS graph CALL export_util.json(graph, '/home/user') "
+    with patch.object(Memgraph, "execute", return_value=None) as mock:
+        query_builder.execute()
+    mock.assert_called_with(expected_query)
+
+
+def test_call_subgraph_with_labels(memgraph):
+    label = "LABEL"
+    query_builder = QueryBuilder().call("export_util.json", "/home/user", node_label=label)
+    expected_query = " MATCH p=(:LABEL)-->(:LABEL) WITH project(p) AS graph CALL export_util.json(graph, '/home/user') "
+    with patch.object(Memgraph, "execute", return_value=None) as mock:
+        query_builder.execute()
+    mock.assert_called_with(expected_query)
+
+
+def test_call_subgraph_with_type(memgraph):
+    relationship_type = "TYPE1"
+    query_builder = QueryBuilder().call("export_util.json", "/home/user", relationship_types=relationship_type)
+    expected_query = " MATCH p=()-[:TYPE1]->() WITH project(p) AS graph CALL export_util.json(graph, '/home/user') "
     with patch.object(Memgraph, "execute", return_value=None) as mock:
         query_builder.execute()
     mock.assert_called_with(expected_query)

--- a/tests/query_builders/test_memgraph_query_builder.py
+++ b/tests/query_builders/test_memgraph_query_builder.py
@@ -100,20 +100,20 @@ def test_call_subgraph_with_type(memgraph):
 
 
 @pytest.mark.parametrize(
-    "subgraph_query, expected_query",
+    "subgraph_path, expected_query",
     [
         (
-            "MATCH path=(n:LABEL1)-[:TYPE1]->(m:LABEL2)",
-            " MATCH path=(n:LABEL1)-[:TYPE1]->(m:LABEL2) WITH project(p) AS graph CALL export_util.json(graph, '/home/user') ",
+            "(n:LABEL1)-[:TYPE1]->(m:LABEL2)",
+            " MATCH p=(n:LABEL1)-[:TYPE1]->(m:LABEL2) WITH project(p) AS graph CALL export_util.json(graph, '/home/user') ",
         ),
         (
-            "MATCH (n:LABEL1)-[:TYPE1 | :TYPE2]->(m:LABEL2)",
+            "(n:LABEL1)-[:TYPE1 | :TYPE2]->(m:LABEL2)",
             " MATCH p=(n:LABEL1)-[:TYPE1 | :TYPE2]->(m:LABEL2) WITH project(p) AS graph CALL export_util.json(graph, '/home/user') ",
         ),
     ],
 )
-def test_call_subgraph_with_query(memgraph, subgraph_query, expected_query):
-    query_builder = QueryBuilder().call("export_util.json", "/home/user", subgraph_query=subgraph_query)
+def test_call_subgraph_with_query(memgraph, subgraph_path, expected_query):
+    query_builder = QueryBuilder().call("export_util.json", "/home/user", subgraph_path=subgraph_path)
     with patch.object(Memgraph, "execute", return_value=None) as mock:
         query_builder.execute()
     mock.assert_called_with(expected_query)

--- a/tests/query_builders/test_memgraph_query_builder.py
+++ b/tests/query_builders/test_memgraph_query_builder.py
@@ -28,7 +28,7 @@ from gqlalchemy.query_builders.memgraph_query_builder import (
     With,
 )
 from gqlalchemy.graph_algorithms.integrated_algorithms import BreadthFirstSearch, DepthFirstSearch, WeightedShortestPath
-from gqlalchemy.utilities import PropertyVariable
+from gqlalchemy.utilities import CypherVariable
 
 
 def test_invalid_match_chain_throws_exception():
@@ -326,7 +326,7 @@ class TestMemgraphBaseClasses:
         mock.assert_called_with(expected_query)
 
     def test_base_class_foreach(self, memgraph):
-        update_clause = Create().node(variable="n", id=PropertyVariable(name="i"))
+        update_clause = Create().node(variable="n", id=CypherVariable(name="i"))
         query_builder = Foreach(variable="i", expression="[1, 2, 3]", update_clauses=update_clause.construct_query())
         expected_query = " FOREACH ( i IN [1, 2, 3] | CREATE (n {id: i}) ) "
 

--- a/tests/query_builders/test_neo4j_query_builder.py
+++ b/tests/query_builders/test_neo4j_query_builder.py
@@ -25,7 +25,7 @@ from gqlalchemy.query_builders.neo4j_query_builder import (
     Unwind,
     With,
 )
-from gqlalchemy.utilities import PropertyVariable
+from gqlalchemy.utilities import CypherVariable
 
 
 class TestNeo4jBaseClasses:
@@ -50,7 +50,7 @@ class TestNeo4jBaseClasses:
         mock.assert_called_with(expected_query)
 
     def test_base_class_foreach(self, neo4j):
-        update_clause = Neo4jQueryBuilder(connection=neo4j).create().node(variable="n", id=PropertyVariable(name="i"))
+        update_clause = Neo4jQueryBuilder(connection=neo4j).create().node(variable="n", id=CypherVariable(name="i"))
         query_builder = Foreach(
             variable="i", expression="[1, 2, 3]", update_clauses=update_clause.construct_query(), connection=neo4j
         )

--- a/tests/query_builders/test_query_builders.py
+++ b/tests/query_builders/test_query_builders.py
@@ -28,7 +28,7 @@ from gqlalchemy.exceptions import (
 from gqlalchemy import Field, InvalidMatchChainException, Node, QueryBuilder, Relationship
 from gqlalchemy.exceptions import GQLAlchemyMissingOrder, GQLAlchemyOrderByTypeError
 from gqlalchemy.query_builders.declarative_base import Operator, Order, _ResultPartialQuery
-from gqlalchemy.utilities import PropertyVariable
+from gqlalchemy.utilities import CypherVariable
 
 
 @pytest.mark.parametrize("vendor", ["neo4j_query_builder", "memgraph_query_builder"], indirect=True)
@@ -1600,7 +1600,7 @@ class TestMemgraphNeo4jQueryBuilder:
             .with_(results={"[1,2,3]": "list"})
             .unwind("list", "element")
             .create()
-            .node(num=PropertyVariable(name="element"))
+            .node(num=CypherVariable(name="element"))
         )
 
         expected_query = " WITH [1,2,3] AS list UNWIND list AS element CREATE ( {num: element})"
@@ -1616,7 +1616,7 @@ class TestMemgraphNeo4jQueryBuilder:
             .with_(results={"15": "number"})
             .create()
             .node(variable="n")
-            .to(relationship_type="REL", num=PropertyVariable(name="number"))
+            .to(relationship_type="REL", num=CypherVariable(name="number"))
             .node(variable="m")
         )
 
@@ -1628,7 +1628,7 @@ class TestMemgraphNeo4jQueryBuilder:
         mock.assert_called_with(expected_query)
 
     def test_foreach(self, vendor):
-        update_clause = QueryBuilder().create().node(variable="n", id=PropertyVariable(name="i"))
+        update_clause = QueryBuilder().create().node(variable="n", id=CypherVariable(name="i"))
         query_builder = vendor[1].foreach(
             variable="i", expression="[1, 2, 3]", update_clause=update_clause.construct_query()
         )
@@ -1640,7 +1640,7 @@ class TestMemgraphNeo4jQueryBuilder:
         mock.assert_called_with(expected_query)
 
     def test_foreach_multiple_update_clauses(self, vendor):
-        variable_li = PropertyVariable(name="li")
+        variable_li = CypherVariable(name="li")
         update_clause_1 = QueryBuilder().create().node(labels="F4", prop=variable_li)
         update_clause_2 = QueryBuilder().create().node(labels="F5", prop2=variable_li)
         query = (
@@ -1664,7 +1664,7 @@ class TestMemgraphNeo4jQueryBuilder:
         mock.assert_called_with(expected_query)
 
     def test_foreach_nested(self, vendor):
-        create_query = QueryBuilder().create().node(variable="u", prop=PropertyVariable(name="j"))
+        create_query = QueryBuilder().create().node(variable="u", prop=CypherVariable(name="j"))
         nested_query = QueryBuilder().foreach(
             variable="j", expression="i", update_clause=create_query.construct_query()
         )


### PR DESCRIPTION
### Description

Added support for graph project feature while trying to make it easy to use. The idea is to pass a node label and relationship types that you want to use in the subgraph to the `call` method for query modules. GQLAlchemy constructs the query for project and inserts the `graph` argument in the query module call. both can be as many as you like. Given that the labels and types are used to construct the match part of the query, I also included the possibility to use `subgraph_query` argument and insert the Cypher path in string form.

Notes:
- I added the ProjectPartialQuery, which is a MATCH - WITH query, I used `DeclarativeBaseTypes.MATCH` as its type. This and the construction of the MATCH query could have been done in other ways, for instance using QueryBuilder methods, but I did it like this since the `WITH project(p) as graph` is so specific. 
- Also, I changed the previously implemented `PropertyVariable` to `CypherVariable`, this is only here to escape the `to_cypher_value` method used to add quotes around string arguments, so we can use variables. Since the `graph` variable is used in the QM call for the subgraph, this was needed.

### Pull request type

- [x] Feature

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

######################################

### Reviewer checklist (the reviewer checks this part)
- [ ] Core feature implementation
- [ ] Tests
- [ ] Code documentation
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)

######################################
