### PR TITLE
[main < ] change Ubuntu and MG version in workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 name: Build and Test
 
 env:
-  MG_VERSION: "2.3.0"
+  MG_VERSION: "2.5.0"
   POETRY_VERSION: "1.2.2"
 
 on:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 name: Build and Test
 
 env:
-  MG_VERSION: "2.5.0"
+  MG_VERSION: "2.2.0"
   POETRY_VERSION: "1.2.2"
 
 on:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 name: Build and Test
 
 env:
-  MG_VERSION: "2.2.0"
+  MG_VERSION: "2.5.0"
   POETRY_VERSION: "1.2.2"
 
 on:
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9"]
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 name: Build and Test
 
 env:
-  MG_VERSION: "2.5.0"
+  MG_VERSION: "2.3.0"
   POETRY_VERSION: "1.2.2"
 
 on:

--- a/gqlalchemy/graph_algorithms/query_builder.py
+++ b/gqlalchemy/graph_algorithms/query_builder.py
@@ -29,10 +29,10 @@ class MemgraphQueryBuilder(QueryBuilder):
     def __init__(self, connection: Optional[Union[Connection, Memgraph]] = None):
         super().__init__(connection)
 
-    def example_procedure(self, required_arg: Any, optional_arg=None) -> DeclarativeBase:
+    def example_c_procedure(self, required_arg: Any, optional_arg=None) -> DeclarativeBase:
         return self.call("example.procedure", (required_arg, optional_arg))
 
-    def example_write_procedure(self, required_arg: str) -> DeclarativeBase:
+    def example_c_write_procedure(self, required_arg: str) -> DeclarativeBase:
         return self.call("example.write_procedure", (required_arg))
 
     def graph_analyzer_analyze(self, analyses: Optional[List[str]] = None) -> DeclarativeBase:


### PR DESCRIPTION
### Description

- Make build-and-test.yml MG_VERSION 2.5.0
- Make Ubuntu version used 20.04 (as it is already in develop), because for some reason 22.04 has that issue that libpython is not installed and needed for memgraph. This is definitely a problem in the future when we want to use the newer Ubuntu.
