### PR TITLE
Update workflows to use newer python and ubuntu

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 name: Build and Test
 
 env:
-  MG_VERSION: "2.17.0"
+  MG_VERSION: "3.1.1"
   POETRY_VERSION: "1.2.2"
   VM_MAX_MAP_COUNT: "262144"
 
@@ -18,14 +18,14 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
-        os: [ubuntu-20.04]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up pip and install packages
@@ -40,7 +40,7 @@ jobs:
       - name: Install Memgraph
         run: |
           mkdir /home/runner/memgraph
-          curl -L https://download.memgraph.com/memgraph/v${{env.MG_VERSION}}/ubuntu-20.04/memgraph_${{env.MG_VERSION}}-1_amd64.deb --output /home/runner/memgraph/memgraph-community.deb
+          curl -L https://download.memgraph.com/memgraph/v${{env.MG_VERSION}}/${{ matrix.os }}/memgraph_${{env.MG_VERSION}}-1_amd64.deb --output /home/runner/memgraph/memgraph-community.deb
           sudo dpkg -i /home/runner/memgraph/memgraph-community.deb
           sudo systemctl stop memgraph
           sudo runuser -l memgraph -c '/usr/lib/memgraph/memgraph --bolt-port 7687 --bolt-session-inactivity-timeout=300 --data-directory="/var/lib/memgraph/data" --storage-properties-on-edges=true --storage-snapshot-interval-sec=0 --storage-wal-enabled=false --storage-recover-on-startup=false --storage-snapshot-on-exit=false --telemetry-enabled=false --log-level=TRACE --also-log-to-stderr=true --log-file=/var/log/memgraph/memgraph-ubuntu-${{ matrix.python-version }}.log' &
@@ -50,8 +50,12 @@ jobs:
           docker run -p 7474:7474 -p 7688:7687 -d -v $HOME/neo4j/data:/data -v $HOME/neo4j/logs:/logs -v $HOME/neo4j/import:/var/lib/neo4j/import -v $HOME/neo4j/plugins:/plugins --env NEO4J_AUTH=neo4j/test neo4j:4.4.7
       - name: Test project
         run: |
-          poetry install --all-extras
-          poe install-pyg-cpu
+          if [[ "${{ matrix.python-version }}" == "3.10" ]]; then
+            poetry install --all-extras
+            poetry install-pyg-cpu
+          else
+            poetry install --extras "arrow docker"
+          fi
           poetry run pytest -vvv -m "not slow and not ubuntu and not docker"
       - name: Use the Upload Artifact GitHub Action
         uses: actions/upload-artifact@v4
@@ -61,51 +65,52 @@ jobs:
           path: /var/log/memgraph
           overwrite: true
 
-  build_and_test_ubuntu_python3_11:
-    if: github.event.pull_request.draft == false
-    strategy:
-      matrix:
-        python-version: ["3.11"]
-        os: [ubuntu-20.04]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Set up pip and install packages
-        run: |
-          python -m pip install -U pip
-          sudo -H pip install networkx numpy scipy
-          sudo -H pip install poethepoet==0.18.1
-      - name: Setup poetry
-        uses: abatilo/actions-poetry@v2.0.0
-        with:
-          poetry-version: ${{ env.POETRY_VERSION }}
-      - name: Install Memgraph
-        run: |
-          mkdir /home/runner/memgraph
-          curl -L https://download.memgraph.com/memgraph/v${{env.MG_VERSION}}/ubuntu-20.04/memgraph_${{env.MG_VERSION}}-1_amd64.deb --output /home/runner/memgraph/memgraph-community.deb
-          sudo dpkg -i /home/runner/memgraph/memgraph-community.deb
-          sudo systemctl stop memgraph
-          sudo runuser -l memgraph -c '/usr/lib/memgraph/memgraph --bolt-port 7687 --bolt-session-inactivity-timeout=300 --data-directory="/var/lib/memgraph/data" --storage-properties-on-edges=true --storage-snapshot-interval-sec=0 --storage-wal-enabled=false --storage-recover-on-startup=false --storage-snapshot-on-exit=false --telemetry-enabled=false --log-level=TRACE --also-log-to-stderr=true --log-file=/var/log/memgraph/memgraph-ubuntu-${{ matrix.python-version }}.log' &
-          sleep 1 # Wait for Memgraph a bit.
-      - name: Install Neo4j
-        run: |
-          docker run -p 7474:7474 -p 7688:7687 -d -v $HOME/neo4j/data:/data -v $HOME/neo4j/logs:/logs -v $HOME/neo4j/import:/var/lib/neo4j/import -v $HOME/neo4j/plugins:/plugins --env NEO4J_AUTH=neo4j/test neo4j:4.4.7
-      - name: Test project
-        run: |
-          poetry install --extras "arrow docker"
-          poetry run pytest -vvv -m "not slow and not ubuntu and not docker and not dgl"
-      - name: Use the Upload Artifact GitHub Action
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: assets-for-download
-          path: /var/log/memgraph
-          overwrite: true
+          #Commented out while testing above...
+  # build_and_test_ubuntu_python3_11:
+  #   if: github.event.pull_request.draft == false
+  #   strategy:
+  #     matrix:
+  #       python-version: ["3.11"]
+  #       os: [ubuntu-20.04]
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - name: Checkout Repository
+  #       uses: actions/checkout@v2
+  #     - name: Set up Python ${{ matrix.python-version }}
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - name: Set up pip and install packages
+  #       run: |
+  #         python -m pip install -U pip
+  #         sudo -H pip install networkx numpy scipy
+  #         sudo -H pip install poethepoet==0.18.1
+  #     - name: Setup poetry
+  #       uses: abatilo/actions-poetry@v2.0.0
+  #       with:
+  #         poetry-version: ${{ env.POETRY_VERSION }}
+  #     - name: Install Memgraph
+  #       run: |
+  #         mkdir /home/runner/memgraph
+  #         curl -L https://download.memgraph.com/memgraph/v${{env.MG_VERSION}}/ubuntu-20.04/memgraph_${{env.MG_VERSION}}-1_amd64.deb --output /home/runner/memgraph/memgraph-community.deb
+  #         sudo dpkg -i /home/runner/memgraph/memgraph-community.deb
+  #         sudo systemctl stop memgraph
+  #         sudo runuser -l memgraph -c '/usr/lib/memgraph/memgraph --bolt-port 7687 --bolt-session-inactivity-timeout=300 --data-directory="/var/lib/memgraph/data" --storage-properties-on-edges=true --storage-snapshot-interval-sec=0 --storage-wal-enabled=false --storage-recover-on-startup=false --storage-snapshot-on-exit=false --telemetry-enabled=false --log-level=TRACE --also-log-to-stderr=true --log-file=/var/log/memgraph/memgraph-ubuntu-${{ matrix.python-version }}.log' &
+  #         sleep 1 # Wait for Memgraph a bit.
+  #     - name: Install Neo4j
+  #       run: |
+  #         docker run -p 7474:7474 -p 7688:7687 -d -v $HOME/neo4j/data:/data -v $HOME/neo4j/logs:/logs -v $HOME/neo4j/import:/var/lib/neo4j/import -v $HOME/neo4j/plugins:/plugins --env NEO4J_AUTH=neo4j/test neo4j:4.4.7
+  #     - name: Test project
+  #       run: |
+  #         poetry install --extras "arrow docker"
+  #         poetry run pytest -vvv -m "not slow and not ubuntu and not docker and not dgl"
+  #     - name: Use the Upload Artifact GitHub Action
+  #       uses: actions/upload-artifact@v4
+  #       if: always()
+  #       with:
+  #         name: assets-for-download
+  #         path: /var/log/memgraph
+  #         overwrite: true
 
   build_and_test_windows:
     if: false
@@ -113,14 +118,14 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up pip and install packages
@@ -132,7 +137,7 @@ jobs:
         run: wsl --set-default-version 2
       - uses: Vampire/setup-wsl@v3
         with:
-          distribution: Ubuntu-22.04
+          distribution: Ubuntu-24.04
       - name: Update vm.max_map_count
         shell: wsl-bash {0} #root shell
         run: sysctl -w vm.max_map_count=${{ env.VM_MAX_MAP_COUNT }}
@@ -143,7 +148,7 @@ jobs:
           sudo apt-get -y install python3 python3-pip ipython3
           pip3 install networkx numpy scipy
           mkdir /memgraph
-          curl -L https://download.memgraph.com/memgraph/v${{env.MG_VERSION}}/ubuntu-22.04/memgraph_${{env.MG_VERSION}}-1_amd64.deb --output /memgraph/memgraph-community.deb
+          curl -L https://download.memgraph.com/memgraph/v${{env.MG_VERSION}}/ubuntu-24.04/memgraph_${{env.MG_VERSION}}-1_amd64.deb --output /memgraph/memgraph-community.deb
           systemctl mask memgraph
           dpkg -i /memgraph/memgraph-community.deb
           mkdir /mnt/c/memgraph


### PR DESCRIPTION
Updating workflows to use Python version `3.10` to `3.13` and Ubuntu 24.04.

