### PR TITLE
Add IN operator to query builder

### DIFF
--- a/gqlalchemy/query_builders/declarative_base.py
+++ b/gqlalchemy/query_builders/declarative_base.py
@@ -86,6 +86,7 @@ class Operator(Enum):
     EQUAL = "="
     GEQ_THAN = ">="
     GREATER_THAN = ">"
+    IN = "IN"
     INEQUAL = "<>"
     LABEL_FILTER = ":"
     LESS_THAN = "<"

--- a/tests/query_builders/test_query_builders.py
+++ b/tests/query_builders/test_query_builders.py
@@ -420,6 +420,23 @@ class TestMemgraphNeo4jQueryBuilder:
 
         mock.assert_called_with(expected_query)
 
+    def test_where_in(self, vendor):
+        query_builder = (
+            vendor[1]
+            .match()
+            .node(labels="L1", variable="n")
+            .to(relationship_type="TO")
+            .node(labels="L2", variable="m")
+            .where(item="n.name", operator=Operator.IN, literal=["best_name", "worst_name"])
+            .return_()
+        )
+        expected_query = ' MATCH (n:L1)-[:TO]->(m:L2) WHERE n.name IN ["best_name", "worst_name"] RETURN * '
+
+        with patch.object(vendor[0], "execute_and_fetch", return_value=None) as mock:
+            query_builder.execute()
+
+        mock.assert_called_with(expected_query)
+
     def test_where_not_label(self, vendor):
         query_builder = (
             vendor[1]


### PR DESCRIPTION
### Description

Adds support for the `IN` operator to the query builder.

### Pull request type

Please delete options that are not relevant.

- [x] Feature

### Related issues

Closes #378 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

######################################

### Reviewer checklist (the reviewer checks this part)
- [ ] Core feature implementation
- [ ] Tests
- [ ] Code documentation
- [ ] Documentation on [gqlalchemy/docs](https://github.com/memgraph/gqlalchemy/tree/main/docs)

######################################
