### PR TITLE
Add data directory lock status query builder

### DIFF
--- a/docs/reference/gqlalchemy/query_builders/memgraph_query_builder.md
+++ b/docs/reference/gqlalchemy/query_builders/memgraph_query_builder.md
@@ -9,6 +9,24 @@ title: gqlalchemy.query_builders.memgraph_query_builder
 class QueryBuilder(DeclarativeBase)
 ```
 
+#### data\_directory\_lock\_status
+
+```python
+def data_directory_lock_status() -> "DeclarativeBase"
+```
+
+Check whether Memgraph data directory locking is currently enabled.
+
+**Returns**:
+
+  A `DeclarativeBase` instance for constructing queries.
+
+
+**Examples**:
+
+- `Python` - `data_directory_lock_status().execute()`
+- `Cypher` - `DATA DIRECTORY LOCK STATUS;`
+
 #### load\_csv
 
 ```python
@@ -89,6 +107,12 @@ Cypher query defining the MATCH clause which selects the nodes and relationships
   
 - `Python` - `call("export_util.json", "/home/user", subgraph_path="(:LABEL)-[:TYPE]->(:LABEL)").execute()`
 - `Cypher` - `MATCH p=(:LABEL)-[:TYPE1]->(:LABEL) WITH project(p) AS graph CALL export_util.json(graph, "/home/user")`
+
+## DataDirectoryLockStatus Objects
+
+```python
+class DataDirectoryLockStatus(DeclarativeBase)
+```
 
 ## ProjectPartialQuery Objects
 

--- a/gqlalchemy/__init__.py
+++ b/gqlalchemy/__init__.py
@@ -57,7 +57,11 @@ from gqlalchemy.query_builders.declarative_base import (  # noqa F401
     Unwind,
     With,
 )
-from gqlalchemy.query_builders.memgraph_query_builder import LoadCsv, QueryBuilder
+from gqlalchemy.query_builders.memgraph_query_builder import (
+    DataDirectoryLockStatus,
+    LoadCsv,
+    QueryBuilder,
+)
 from gqlalchemy.query_builders.neo4j_query_builder import Neo4jQueryBuilder  # noqa F401
 from gqlalchemy.vendors.memgraph import Memgraph  # noqa F401
 from gqlalchemy.vendors.neo4j import Neo4j  # noqa F401
@@ -74,4 +78,5 @@ with_ = With
 foreach = Foreach
 return_ = Return
 load_csv = LoadCsv
+data_directory_lock_status = DataDirectoryLockStatus
 MemgraphQueryBuilder = QueryBuilder

--- a/gqlalchemy/query_builders/memgraph_query_builder.py
+++ b/gqlalchemy/query_builders/memgraph_query_builder.py
@@ -36,7 +36,16 @@ from gqlalchemy.utilities import CypherVariable, CypherNode, CypherRelationship,
 
 
 class MemgraphQueryBuilderTypes(DeclarativeBaseTypes):
+    DATA_DIRECTORY_LOCK_STATUS = "DATA_DIRECTORY_LOCK_STATUS"
     LOAD_CSV = "LOAD_CSV"
+
+
+class DataDirectoryLockStatusPartialQuery(PartialQuery):
+    def __init__(self):
+        super().__init__(MemgraphQueryBuilderTypes.DATA_DIRECTORY_LOCK_STATUS)
+
+    def construct_query(self) -> str:
+        return " DATA DIRECTORY LOCK STATUS "
 
 
 class LoadCsvPartialQuery(PartialQuery):
@@ -53,6 +62,21 @@ class LoadCsvPartialQuery(PartialQuery):
 class QueryBuilder(DeclarativeBase):
     def __init__(self, connection: Optional[Memgraph] = None):
         super().__init__(connection)
+
+    def data_directory_lock_status(self) -> "DeclarativeBase":
+        """Check whether Memgraph data directory locking is currently enabled.
+
+        Returns:
+            A `DeclarativeBase` instance for constructing queries.
+
+        Examples:
+            Python: `data_directory_lock_status().execute()`
+            Cypher: `DATA DIRECTORY LOCK STATUS;`
+        """
+        self._query.append(DataDirectoryLockStatusPartialQuery())
+        self._fetch_results = True
+
+        return self
 
     def load_csv(self, path: str, header: bool, row: str) -> "DeclarativeBase":
         """Load data from a CSV file by executing a Cypher query for each row.
@@ -198,6 +222,13 @@ class LoadCsv(DeclarativeBase):
     def __init__(self, path: str, header: bool, row: str, connection: Optional[DatabaseClient] = None):
         super().__init__(connection)
         self._query.append(LoadCsvPartialQuery(path, header, row))
+
+
+class DataDirectoryLockStatus(DeclarativeBase):
+    def __init__(self, connection: Optional[DatabaseClient] = None):
+        super().__init__(connection)
+        self._query.append(DataDirectoryLockStatusPartialQuery())
+        self._fetch_results = True
 
 
 class ProjectPartialQuery(PartialQuery):

--- a/tests/query_builders/test_memgraph_query_builder.py
+++ b/tests/query_builders/test_memgraph_query_builder.py
@@ -15,7 +15,13 @@
 import pytest
 from unittest.mock import patch
 
-from gqlalchemy import InvalidMatchChainException, Memgraph, QueryBuilder
+from gqlalchemy import (
+    DataDirectoryLockStatus,
+    InvalidMatchChainException,
+    Memgraph,
+    QueryBuilder,
+    data_directory_lock_status,
+)
 from gqlalchemy.query_builders.memgraph_query_builder import (
     Call,
     Create,
@@ -53,6 +59,14 @@ def test_load_csv_with_header(memgraph):
 def test_load_csv_no_header(memgraph):
     query_builder = QueryBuilder().load_csv(path="path/to/my/file.csv", header=False, row="row").return_()
     expected_query = " LOAD CSV FROM 'path/to/my/file.csv' NO HEADER AS row RETURN * "
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+    mock.assert_called_with(expected_query)
+
+
+def test_data_directory_lock_status():
+    query_builder = QueryBuilder().data_directory_lock_status()
+    expected_query = " DATA DIRECTORY LOCK STATUS "
     with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
         query_builder.execute()
     mock.assert_called_with(expected_query)
@@ -197,6 +211,26 @@ def test_yield_multiple_alias(memgraph):
 def test_base_class_load_csv(memgraph):
     query_builder = LoadCsv("path/to/my/file.csv", True, "row").return_()
     expected_query = " LOAD CSV FROM 'path/to/my/file.csv' WITH HEADER AS row RETURN * "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
+def test_base_class_data_directory_lock_status():
+    query_builder = DataDirectoryLockStatus()
+    expected_query = " DATA DIRECTORY LOCK STATUS "
+
+    with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
+        query_builder.execute()
+
+    mock.assert_called_with(expected_query)
+
+
+def test_function_data_directory_lock_status():
+    query_builder = data_directory_lock_status()
+    expected_query = " DATA DIRECTORY LOCK STATUS "
 
     with patch.object(Memgraph, "execute_and_fetch", return_value=None) as mock:
         query_builder.execute()


### PR DESCRIPTION
## Summary
- Add a Memgraph query builder method for DATA DIRECTORY LOCK STATUS.
- Expose a top-level data_directory_lock_status helper/class.
- Document and test that the query uses execute_and_fetch.

Fixes #253

## Tests
- Targeted pytest for data_directory_lock_status tests passed.
- Black check passed for touched Python files.