### PR TITLE
fix publish docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -24,4 +24,4 @@ jobs:
 
       - name: Publish docs
         run: |
-          mkdocs gh-deploy
+          mkdocs gh-deploy --force


### PR DESCRIPTION
### Description

GitHub pages branch requires a force-push to overwrite the docs deployment if it was made on a branch with commits that the current branch does not. 

### Pull request type

Please delete options that are not relevant.

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring with functional or API changes
- [ ] Refactoring without functional or API changes
- [ ] Build or packaging related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Related issues

Delete section if this PR doesn't resolve any issues. 

Closes (link to issue)

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

######################################

### Reviewer checklist (the reviewer checks this part)
- [ ] Core feature implementation
- [ ] Tests
- [ ] Code documentation
- [ ] Documentation on [gqlalchemy/docs](https://github.com/memgraph/gqlalchemy/tree/main/docs)

######################################
